### PR TITLE
Contracts: Allow owner to change MACI parameters

### DIFF
--- a/contracts/contracts/FundingRoundFactory.sol
+++ b/contracts/contracts/FundingRoundFactory.sol
@@ -18,9 +18,6 @@ import './FundingRound.sol';
 contract FundingRoundFactory is Ownable, MACIPubKey {
   using SafeERC20 for IERC20;
 
-  // Constants
-  uint256 private constant MACI_MAX_VOTE_OPTIONS = 625;
-
   // State
   mapping(address => string) public recipients;
   uint256 private recipientCount = 0;
@@ -75,7 +72,7 @@ contract FundingRoundFactory is Ownable, MACIPubKey {
     require(_fundingAddress != address(0), 'Factory: Recipient address is zero');
     require(bytes(_name).length != 0, 'Factory: Recipient name is empty string');
     require(bytes(recipients[_fundingAddress]).length == 0, 'Factory: Recipient already registered');
-    require(recipientCount < MACI_MAX_VOTE_OPTIONS, 'Factory: Recipient limit reached');
+    require(recipientCount < maciFactory.maxVoteOptions(), 'Factory: Recipient limit reached');
     recipients[_fundingAddress] = _name;
     recipientCount += 1;
     emit RecipientAdded(_fundingAddress, _name);
@@ -93,17 +90,36 @@ contract FundingRoundFactory is Ownable, MACIPubKey {
     return previousRound;
   }
 
-  function deployMaci(
+  function setMaciParameters(
+    uint8 _stateTreeDepth,
+    uint8 _messageTreeDepth,
+    uint8 _voteOptionTreeDepth,
+    uint8 _tallyBatchSize,
+    uint8 _messageBatchSize,
     uint256 _signUpDuration,
-    uint256 _votingDuration,
+    uint256 _votingDuration
+  )
+    public
+    onlyOwner
+  {
+    maciFactory.setMaciParameters(
+      _stateTreeDepth,
+      _messageTreeDepth,
+      _voteOptionTreeDepth,
+      _tallyBatchSize,
+      _messageBatchSize,
+      _signUpDuration,
+      _votingDuration
+    );
+  }
+
+  function deployMaci(
     PubKey memory _coordinatorPubKey
   )
     public
     onlyOwner
   {
     maciFactory.deployMaci(
-      _signUpDuration,
-      _votingDuration,
       _coordinatorPubKey
     );
   }

--- a/contracts/tests/factory.ts
+++ b/contracts/tests/factory.ts
@@ -4,7 +4,7 @@ import { deployContract, solidity } from 'ethereum-waffle';
 import { ethers } from 'ethers';
 
 import { deployMaciFactory } from '../scripts/helpers';
-import { getGasUsage } from './utils';
+import { getGasUsage, MaciParameters } from './utils';
 
 import RoundArtifact from '../build/contracts/FundingRound.json';
 import FactoryArtifact from '../build/contracts/FundingRoundFactory.json';
@@ -21,12 +21,15 @@ describe('Funding Round Factory', () => {
 
   const [dontUseMe, deployer, coordinator, contributor] = provider.getWallets();
 
+  let maciFactory: ethers.Contract;
   let factory: ethers.Contract;
   let token;
   let tokenContractAsContributor;
 
+  let maciParameters = new MaciParameters();
+
   beforeEach(async () => {
-    const maciFactory = await deployMaciFactory(deployer);
+    maciFactory = await deployMaciFactory(deployer);
 
     factory = await deployContract(deployer, FactoryArtifact, [
       maciFactory.address,
@@ -101,7 +104,11 @@ describe('Funding Round Factory', () => {
     });
 
     it('should limit the number of recipients', async () => {
-      const maxRecipientCount = 625;
+      // Reduce number of vote options to speed up the test
+      maciParameters = new MaciParameters({ voteOptionTreeDepth: 1 });
+      await factory.setMaciParameters(...maciParameters.values());
+
+      const maxRecipientCount = 4;
       for (var i = 0; i < maxRecipientCount + 1; i++) {
         recipientName = String(i + 1).padStart(4, '0');
         fundingAddress = `0x000000000000000000000000000000000000${recipientName}`;
@@ -115,14 +122,21 @@ describe('Funding Round Factory', () => {
     });
   });
 
+  it('sets MACI parameters', async () => {
+    await expect(factory.setMaciParameters(...maciParameters.values()))
+      .to.emit(maciFactory, 'MaciParametersChanged');
+  });
+
+  it('allows only owner to set MACI parameters', async () => {
+    const coordinatorFactory = factory.connect(coordinator);
+    await expect(coordinatorFactory.setMaciParameters(...maciParameters.values()))
+      .to.be.revertedWith('Ownable: caller is not the owner');
+  });
+
   it('deploys MACI', async () => {
-    const signUpDuration = 86400;
-    const votingDuration = 86400;
     const coordinatorPubKey = { x: 0, y: 1 };
 
     const deployTx = await factory.deployMaci(
-      signUpDuration,
-      votingDuration,
       coordinatorPubKey,
     );
     expect(await getGasUsage(deployTx)).lessThan(7000000);

--- a/contracts/tests/utils.ts
+++ b/contracts/tests/utils.ts
@@ -9,3 +9,34 @@ export async function getGasUsage(transaction: TransactionResponse): Promise<Num
     return null;
   }
 }
+
+export class MaciParameters {
+
+  // Defaults for tests
+  stateTreeDepth = 4;
+  messageTreeDepth = 4;
+  voteOptionTreeDepth = 2;
+  tallyBatchSize = 2;
+  messageBatchSize = 2;
+  signUpDuration = 3600;
+  votingDuration = 3600;
+
+  constructor(parameters: {[name: string]: number} = {}) {
+    for (const [name, value] of Object.entries(parameters)) {
+      (this as any)[name] = value;
+    }
+  }
+
+  values(): number[] {
+    // To be passed to setMaciParameters()
+    return [
+      this.stateTreeDepth,
+      this.messageTreeDepth,
+      this.voteOptionTreeDepth,
+      this.tallyBatchSize,
+      this.messageBatchSize,
+      this.signUpDuration,
+      this.votingDuration,
+    ];
+  }
+}


### PR DESCRIPTION
All MACI parameters are configurable now.

Owner should call `setMaciParameters()` method on the `FundingRoundFactory` contract, which in turn will call  `MACIFactory.setMaciParameters()`. This is because `MACIFactory` contract is owned by the `FundingRoundFactory`.

Alternatively, we can change the owner of `MACIFactory` and allow Owner to call `MACIFactory.setMaciParameters()` directly, but I chose current implementation because it creates a single entry point for all Owner's calls.

Resolves #42 