### PR TITLE
Contracts: Rewrite factory and funding round contracts

### DIFF
--- a/contracts/contracts/FundingRound.sol
+++ b/contracts/contracts/FundingRound.sol
@@ -73,7 +73,7 @@ contract FundingRound is Ownable, MACIPubKey {
     // bool verified = maci.verifyTallyResult(...);
     // TODO: do calculation properly; rounding
     uint256 finalAmount = _poolShare * poolSize / 100;
-    nativeToken.transferFrom(address(this), msg.sender, finalAmount);
+    nativeToken.transfer(msg.sender, finalAmount);
     emit FundsClaimed(msg.sender);
   }
 
@@ -114,8 +114,9 @@ contract FundingRound is Ownable, MACIPubKey {
     onlyOwner
   {
     require(!isFinalized, 'FundingRound: Already finalized');
+    require(address(maci) != address(0), 'FundingRound: MACI not deployed');
     require(maci.calcVotingDeadline() < now, 'FundingRound: Voting has not been finished');
-    require(!maci.hasUntalliedStateLeaves(), 'FundingRound: Votes has not been tallied');
+    require(maci.numSignUps() == 0 || !maci.hasUntalliedStateLeaves(), 'FundingRound: Votes has not been tallied');
     isFinalized = true;
     poolSize = nativeToken.balanceOf(address(this));
   }

--- a/contracts/contracts/FundingRound.sol
+++ b/contracts/contracts/FundingRound.sol
@@ -27,6 +27,8 @@ contract FundingRound is MACIPubKey {
   event FundsClaimed(address _recipient);
   event NewContribution(address indexed _sender, uint256 amount);
 
+  uint256 public counter;
+
   constructor(
     FundingRoundFactory _parent,
     IERC20 _nativeToken,
@@ -68,7 +70,7 @@ contract FundingRound is MACIPubKey {
     */
   function claimFunds(
     uint256 _poolShare,
-    uint256[][] memory _proof,
+    uint256[][] memory _proof
   )
     public
   {
@@ -90,6 +92,8 @@ contract FundingRound is MACIPubKey {
     PubKey memory pubKey,
     uint256 amount
   ) public {
+    require(address(maci) != address(0), 'FundingRound: MACI not deployed');
+    require(counter < maci.maxUsers(), 'FundingRound: Contributor limit reached');
     require(now < contributionDeadline, 'FundingRound: Contribution period ended');
     require(isFinalized == false, 'FundingRound: Round finalized');
     // TODO: check BrightID verification
@@ -101,6 +105,7 @@ contract FundingRound is MACIPubKey {
       signUpGatekeeperData,
       initialVoiceCreditProxyData
     );
+    counter += 1;
     emit NewContribution(msg.sender, amount);
   }
 

--- a/contracts/contracts/FundingRound.sol
+++ b/contracts/contracts/FundingRound.sol
@@ -27,6 +27,7 @@ contract FundingRound is MACIPubKey {
   event FundsClaimed(address _recipient);
   event NewContribution(address indexed _sender, uint256 amount);
 
+  mapping(address => uint256) public contributors;
   uint256 public counter;
 
   constructor(
@@ -95,7 +96,9 @@ contract FundingRound is MACIPubKey {
     require(address(maci) != address(0), 'FundingRound: MACI not deployed');
     require(counter < maci.maxUsers(), 'FundingRound: Contributor limit reached');
     require(now < contributionDeadline, 'FundingRound: Contribution period ended');
-    require(isFinalized == false, 'FundingRound: Round finalized');
+    require(!isFinalized, 'FundingRound: Round finalized');
+    require(amount > 0, 'FundingRound: Contribution amount must be greater than zero');
+    require(contributors[msg.sender] == 0, 'FundingRound: Already contributed');
     // TODO: check BrightID verification
     bytes memory signUpGatekeeperData = '';
     bytes memory initialVoiceCreditProxyData = abi.encode(amount);
@@ -105,6 +108,7 @@ contract FundingRound is MACIPubKey {
       signUpGatekeeperData,
       initialVoiceCreditProxyData
     );
+    contributors[msg.sender] = amount;
     counter += 1;
     emit NewContribution(msg.sender, amount);
   }

--- a/contracts/contracts/FundingRound.sol
+++ b/contracts/contracts/FundingRound.sol
@@ -23,11 +23,17 @@ contract FundingRound is Ownable, MACIPubKey {
   uint256 public poolSize;
 
   event FundsClaimed(address _recipient);
-  event NewContribution(address indexed _sender, uint256 amount);
+  event NewContribution(address indexed _sender, uint256 _amount);
 
   mapping(address => uint256) public contributors;
   uint256 public counter;
 
+  /**
+    * @dev Sets round parameters (they can only be set once during construction).
+    * @param _nativeToken Address of a token which will be accepted for contributions.
+    * @param _duration Duration of the contribution period in seconds.
+    * @param _coordinatorPubKey Coordinator's public key.
+    */
   constructor(
     IERC20 _nativeToken,
     uint256 _duration,

--- a/contracts/contracts/FundingRound.sol
+++ b/contracts/contracts/FundingRound.sol
@@ -114,12 +114,15 @@ contract FundingRound is MACIPubKey {
   }
 
   /**
-    * @dev Allow recipients to claim funds.
+    * @dev Allow recipients to claim funds after vote tally was done.
     */
   function finalize()
     public
     onlyFactory
   {
+    require(!isFinalized, 'FundingRound: Already finalized');
+    require(maci.calcVotingDeadline() < now, 'FundingRound: Voting has not been finished');
+    require(!maci.hasUntalliedStateLeaves(), 'FundingRound: Votes has not been tallied');
     isFinalized = true;
     poolSize = nativeToken.balanceOf(address(this));
   }

--- a/contracts/contracts/FundingRoundFactory.sol
+++ b/contracts/contracts/FundingRoundFactory.sol
@@ -126,7 +126,6 @@ contract FundingRoundFactory is Ownable, MACIPubKey {
     );
     uint256 signUpDuration = maciFactory.signUpDuration();
     FundingRound newRound = new FundingRound(
-      this,
       nativeToken,
       signUpDuration,
       coordinatorPubKey

--- a/contracts/contracts/FundingRoundFactory.sol
+++ b/contracts/contracts/FundingRoundFactory.sol
@@ -91,6 +91,11 @@ contract FundingRoundFactory is Ownable, MACIPubKey {
     public
     onlyOwner
   {
+    FundingRound currentRound = getCurrentRound();
+    require(
+      address(currentRound) == address(0) || address(currentRound.maci()) != address(0),
+      'Factory: Waiting for MACI deployment'
+    );
     maciFactory.setMaciParameters(
       _stateTreeDepth,
       _messageTreeDepth,

--- a/contracts/contracts/FundingRoundFactory.sol
+++ b/contracts/contracts/FundingRoundFactory.sol
@@ -152,15 +152,18 @@ contract FundingRoundFactory is Ownable, MACIPubKey {
   }
 
   /**
-    * @dev Transfer funds from matching pool to funding round and finalize it.
+    * @dev Transfer funds from matching pool to current funding round and finalize it.
     */
   function transferMatchingFunds()
     public
     onlyOwner
   {
     FundingRound currentRound = getCurrentRound();
+    require(address(currentRound) != address(0), 'Factory: Funding round has not been deployed');
     uint256 amount = currentRound.nativeToken().balanceOf(address(this));
-    nativeToken.transferFrom(address(this), address(currentRound), amount);
+    if (amount > 0) {
+      nativeToken.transfer(address(currentRound), amount);
+    }
     currentRound.finalize();
     emit RoundFinalized(address(currentRound));
   }

--- a/contracts/contracts/FundingRoundFactory.sol
+++ b/contracts/contracts/FundingRoundFactory.sol
@@ -48,11 +48,12 @@ contract FundingRoundFactory is Ownable, MACIPubKey {
   /**
     * @dev Contribute tokens to the matching pool.
     */
-  function contribute(uint256 amount)
+  function contribute(uint256 _amount)
     public
   {
-    nativeToken.transferFrom(msg.sender, address(this), amount);
-    emit NewContribution(msg.sender, amount);
+    require(address(nativeToken) != address(0), 'Factory: Native token is not set');
+    nativeToken.transferFrom(msg.sender, address(this), _amount);
+    emit NewContribution(msg.sender, _amount);
   }
 
   function addRecipient(address _fundingAddress, string memory _name)
@@ -116,6 +117,7 @@ contract FundingRoundFactory is Ownable, MACIPubKey {
     returns (FundingRound _newRound)
   {
     require(maciFactory.owner() == address(this), 'Factory: MACI factory is not owned by FR factory');
+    require(address(nativeToken) != address(0), 'Factory: Native token is not set');
     require(coordinator != address(0), 'Factory: No coordinator');
     FundingRound currentRound = getCurrentRound();
     require(
@@ -142,6 +144,7 @@ contract FundingRoundFactory is Ownable, MACIPubKey {
     onlyOwner
   {
     FundingRound currentRound = getCurrentRound();
+    require(address(currentRound) != address(0), 'Factory: Funding round has not been deployed');
     require(address(currentRound.maci()) == address(0), 'Factory: MACI already deployed');
     (uint256 x, uint256 y) = currentRound.coordinatorPubKey();
     PubKey memory roundCoordinatorPubKey = PubKey(x, y);
@@ -156,8 +159,8 @@ contract FundingRoundFactory is Ownable, MACIPubKey {
     public
     onlyOwner
   {
-    uint256 amount = nativeToken.balanceOf(address(this));
     FundingRound currentRound = getCurrentRound();
+    uint256 amount = currentRound.nativeToken().balanceOf(address(this));
     nativeToken.transferFrom(address(this), address(currentRound), amount);
     currentRound.finalize();
     emit RoundFinalized(address(currentRound));

--- a/contracts/contracts/InitialVoiceCreditProxy.sol
+++ b/contracts/contracts/InitialVoiceCreditProxy.sol
@@ -2,9 +2,18 @@ pragma solidity ^0.5.0;
 
 import 'maci/contracts/sol/initialVoiceCreditProxy/InitialVoiceCreditProxy.sol';
 
+/**
+ * @dev Implementation of the InitialVoiceCreditProxy interface.
+ */
 contract FundingRoundVoiceCreditProxy is InitialVoiceCreditProxy {
+
+  /**
+    * @dev Get the amount of voice credits for a given contributor.
+    * @param _contributor Contributor's address.
+    * @param _data Encoded amount.
+    */
   function getVoiceCredits(
-    address _user,
+    address _contributor,
     bytes memory _data
   )
     public

--- a/contracts/contracts/InitialVoiceCreditProxy.sol
+++ b/contracts/contracts/InitialVoiceCreditProxy.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.5.0;
+
+import 'maci/contracts/sol/initialVoiceCreditProxy/InitialVoiceCreditProxy.sol';
+
+contract FundingRoundVoiceCreditProxy is InitialVoiceCreditProxy {
+  function getVoiceCredits(
+    address _user,
+    bytes memory _data
+  )
+    public
+    view
+    returns (uint256)
+  {
+    uint256 initialVoiceCredit = abi.decode(_data, (uint256));
+    return initialVoiceCredit;
+  }
+}

--- a/contracts/contracts/InitialVoiceCreditProxy.sol
+++ b/contracts/contracts/InitialVoiceCreditProxy.sol
@@ -9,7 +9,7 @@ contract FundingRoundVoiceCreditProxy is InitialVoiceCreditProxy {
 
   /**
     * @dev Get the amount of voice credits for a given contributor.
-    * @param _contributor Contributor's address.
+    * @param _contributor Contributor's address (or the address of the funding round contract).
     * @param _data Encoded amount.
     */
   function getVoiceCredits(

--- a/contracts/contracts/MACIFactory.sol
+++ b/contracts/contracts/MACIFactory.sol
@@ -5,9 +5,10 @@ import '@openzeppelin/contracts/ownership/Ownable.sol';
 import 'maci/contracts/sol/MACI.sol';
 import 'maci/contracts/sol/MACIParameters.sol';
 import 'maci/contracts/sol/gatekeepers/FreeForAllSignUpGatekeeper.sol';
-import 'maci/contracts/sol/initialVoiceCreditProxy/ConstantInitialVoiceCreditProxy.sol';
 import { BatchUpdateStateTreeVerifier } from 'maci/contracts/sol/BatchUpdateStateTreeVerifier.sol';
 import { QuadVoteTallyVerifier } from 'maci/contracts/sol/QuadVoteTallyVerifier.sol';
+
+import './InitialVoiceCreditProxy.sol';
 
 contract MACIFactory is Ownable, MACIParameters {
   // Constants
@@ -30,7 +31,7 @@ contract MACIFactory is Ownable, MACIParameters {
   FreeForAllGatekeeper private signUpGatekeeper;
   BatchUpdateStateTreeVerifier private batchUstVerifier;
   QuadVoteTallyVerifier private qvtVerifier;
-  ConstantInitialVoiceCreditProxy private initialVoiceCreditProxy;
+  FundingRoundVoiceCreditProxy private initialVoiceCreditProxy;
 
   // Events
   event MaciParametersChanged();
@@ -40,7 +41,7 @@ contract MACIFactory is Ownable, MACIParameters {
     FreeForAllGatekeeper _signUpGatekeeper,
     BatchUpdateStateTreeVerifier _batchUstVerifier,
     QuadVoteTallyVerifier _qvtVerifier,
-    ConstantInitialVoiceCreditProxy _initialVoiceCreditProxy
+    FundingRoundVoiceCreditProxy _initialVoiceCreditProxy
   )
     public
   {

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clrfund/contracts",
   "version": "0.1.0",
-  "main": "index.js",
+  "license": "GPL-3.0",
   "scripts": {
     "build": "buidler compile",
     "node": "buidler node --port 18545",

--- a/contracts/scripts/deploy.ts
+++ b/contracts/scripts/deploy.ts
@@ -21,7 +21,6 @@ async function main() {
   }
   const fundingRoundFactory = await FundingRoundFactory.deploy(
     maciFactory.address,
-    firstCoordinator,
   );
 
   // The address that the Contract WILL have once mined

--- a/contracts/scripts/helpers.ts
+++ b/contracts/scripts/helpers.ts
@@ -32,7 +32,7 @@ export async function deployMaciFactory(account: Signer): Promise<Contract> {
   const signUpGatekeeper = await deployContract(account, 'FreeForAllGatekeeper');
   const batchTreeVerifier = await deployContract(account, 'BatchUpdateStateTreeVerifier');
   const voteTallyVerifier = await deployContract(account, 'QuadVoteTallyVerifier');
-  const initialVoiceCreditProxy = await deployContract(account, 'ConstantInitialVoiceCreditProxy', [0]);
+  const initialVoiceCreditProxy = await deployContract(account, 'FundingRoundVoiceCreditProxy');
   const poseidonT3 = await deployContract(account, 'PoseidonT3');
   const poseidonT6 = await deployContract(account, 'PoseidonT6');
 

--- a/contracts/tests/factory.ts
+++ b/contracts/tests/factory.ts
@@ -33,7 +33,6 @@ describe('Funding Round Factory', () => {
 
     factory = await deployContract(deployer, FactoryArtifact, [
       maciFactory.address,
-      coordinator.address,
     ]);
 
     expect(factory.address).to.properAddress;
@@ -135,23 +134,31 @@ describe('Funding Round Factory', () => {
 
   it('deploys MACI', async () => {
     const coordinatorPubKey = { x: 0, y: 1 };
-
-    const deployTx = await factory.deployMaci(
+    await factory.setCoordinator(
+      coordinator.address,
       coordinatorPubKey,
     );
+    await factory.deployNewRound();
+
+    const deployTx = await factory.deployMaci();
     expect(await getGasUsage(deployTx)).lessThan(7000000);
   });
 
   it('has new round running', async () => {
-    expect(await factory.currentRound()).to.properAddress;
+    expect(await factory.getCurrentRound()).to.properAddress;
   });
 
   it('set contract owner/witness/coordinator/round duration correctly', async () => {
+    const coordinatorPubKey = { x: 0, y: 1 };
+    await factory.setCoordinator(
+      coordinator.address,
+      coordinatorPubKey,
+    );
     expect(await factory.coordinator()).to.eq(coordinator.address);
   });
 
   it('allows user to contribute to current round', async () => {
-    const contractAddress = await factory.currentRound();
+    const contractAddress = await factory.getCurrentRound();
     console.log('About to build contract');
     console.log({ contractAddress });
 

--- a/contracts/tests/factory.ts
+++ b/contracts/tests/factory.ts
@@ -264,6 +264,17 @@ describe('Funding Round Factory', () => {
     it('moves matching funds to the current round after its finalization', async () => {
       // TODO: add tests later; needs time travel
     });
+
+    it('reverts if round has not been deployed', async () => {
+      await factory.setToken(token.address);
+      await factory.setCoordinator(coordinator.address, coordinatorPubKey);
+      await expect(factory.transferMatchingFunds())
+        .to.be.revertedWith('Factory: Funding round has not been deployed');
+    });
+
+    it('finalizes current round even if matching pool is empty', async () => {
+      // TODO: add tests later
+    });
   });
 
   it('allows owner to set native token', async () => {

--- a/contracts/tests/factory.ts
+++ b/contracts/tests/factory.ts
@@ -171,6 +171,7 @@ describe('Funding Round Factory', () => {
         'FundingRound',
         fundingRoundAddress,
       );
+      expect(await fundingRound.owner()).to.equal(factory.address);
       expect(await fundingRound.nativeToken()).to.equal(token.address);
       const roundCoordinatorPubKey = await fundingRound.coordinatorPubKey();
       expect(parseInt(roundCoordinatorPubKey[0])).to.equal(coordinatorPubKey.x);
@@ -261,7 +262,7 @@ describe('Funding Round Factory', () => {
 
   describe('transferring matching funds', () => {
     it('moves matching funds to the current round after its finalization', async () => {
-      // TODO: time travel
+      // TODO: add tests later; needs time travel
     });
   });
 

--- a/contracts/tests/initialVoiceCreditProxy.ts
+++ b/contracts/tests/initialVoiceCreditProxy.ts
@@ -1,0 +1,32 @@
+import { ethers, waffle } from '@nomiclabs/buidler';
+import { use, expect } from 'chai';
+import { solidity } from 'ethereum-waffle';
+import { Contract } from 'ethers';
+import { defaultAbiCoder } from 'ethers/utils/abi-coder';
+
+import { ZERO_ADDRESS } from './utils';
+
+use(solidity);
+
+describe('Initial voice credit proxy', () => {
+  const provider = waffle.provider;
+  const [dontUseMe, deployer] = provider.getWallets();
+
+  let initialVoiceCreditProxy: Contract;
+
+  beforeEach(async () => {
+    const InitialVoiceCreditProxy = await ethers.getContractFactory(
+        'FundingRoundVoiceCreditProxy',
+        deployer,
+    );
+    initialVoiceCreditProxy = await InitialVoiceCreditProxy.deploy();
+  });
+
+  it('decodes the amount of voice credits', async () => {
+    const contributor = ZERO_ADDRESS;
+    const amount = 1000;
+    const encoded = defaultAbiCoder.encode(['uint256'], [amount]);
+    expect(await initialVoiceCreditProxy.getVoiceCredits(contributor, encoded))
+      .to.equal(amount);
+  });
+});

--- a/contracts/tests/round.ts
+++ b/contracts/tests/round.ts
@@ -1,0 +1,146 @@
+import { ethers, waffle } from '@nomiclabs/buidler';
+import { use, expect } from 'chai';
+import { solidity } from 'ethereum-waffle';
+import { Contract } from 'ethers';
+
+import { deployMaciFactory } from '../scripts/helpers';
+import { ZERO_ADDRESS, getGasUsage, getEventArg, MaciParameters } from './utils';
+import MACIArtifact from '../build/contracts/MACI.json';
+
+use(solidity);
+
+describe('Funding Round', () => {
+  const provider = waffle.provider;
+  const [dontUseMe, deployer, coordinator, contributor] = provider.getWallets();
+
+  const coordinatorPubKey = { x: 0, y: 1 };
+  const roundDuration = 86400 * 7;
+
+  let token: Contract;
+  let fundingRound: Contract;
+  let maci: Contract;
+
+  beforeEach(async () => {
+    const tokenInitialSupply = 10000000000;
+    const Token = await ethers.getContractFactory('AnyOldERC20Token', deployer);
+    token = await Token.deploy(tokenInitialSupply);
+    await token.transfer(contributor.address, tokenInitialSupply);
+
+    const FundingRound = await ethers.getContractFactory('FundingRound', deployer);
+    fundingRound = await FundingRound.deploy(
+      token.address,
+      roundDuration,
+      coordinatorPubKey,
+    );
+
+    const maciFactory = await deployMaciFactory(deployer);
+    const maciDeployed = await maciFactory.deployMaci(coordinatorPubKey);
+    const maciAddress = await getEventArg(maciDeployed, maciFactory, 'MaciDeployed', '_maci');
+    maci = await ethers.getContractAt(MACIArtifact.abi, maciAddress);
+  });
+
+  it('initializes funding round correctly', async () => {
+    expect(await fundingRound.owner()).to.equal(deployer.address);
+    expect(await fundingRound.nativeToken()).to.equal(token.address);
+    expect(await fundingRound.isFinalized()).to.equal(false);
+    expect(await fundingRound.maci()).to.equal(ZERO_ADDRESS);
+  });
+
+  it('allows owner to set MACI address', async () => {
+    await fundingRound.setMaci(maci.address);
+    expect(await fundingRound.maci()).to.equal(maci.address);
+  });
+
+  it('allows to set MACI address only once', async () => {
+    await fundingRound.setMaci(maci.address);
+    await expect(fundingRound.setMaci(maci.address))
+      .to.be.revertedWith('FundingRound: Already linked to MACI instance');
+  });
+
+  it('allows only owner to set MACI address', async () => {
+    const fundingRoundAsCoordinator = fundingRound.connect(coordinator);
+    await expect(fundingRoundAsCoordinator.setMaci(maci.address))
+      .to.be.revertedWith('Ownable: caller is not the owner');
+  });
+
+  describe('accepting contributions', () => {
+    const userPubKey = { x: 1, y: 0 };
+    const contributionAmount = 1000;
+    let tokenAsContributor: Contract;
+    let fundingRoundAsContributor: Contract;
+
+    beforeEach(async () => {
+      tokenAsContributor = token.connect(contributor);
+      fundingRoundAsContributor = fundingRound.connect(contributor);
+    });
+
+    it('accepts contributions from everyone', async () => {
+      await fundingRound.setMaci(maci.address);
+      await tokenAsContributor.approve(
+        fundingRound.address,
+        contributionAmount,
+      );
+      await expect(fundingRoundAsContributor.contribute(userPubKey, contributionAmount))
+        .to.emit(fundingRound, 'NewContribution')
+        .withArgs(contributor.address, contributionAmount)
+        .to.emit(maci, 'SignUp')
+        // We use [] to skip argument matching, otherwise it will fail
+        // Possibly related: https://github.com/EthWorks/Waffle/issues/245
+        .withArgs([], 1, contributionAmount);
+      expect(await token.balanceOf(fundingRound.address))
+        .to.equal(contributionAmount);
+    });
+
+    it('rejects contributions if MACI has not been linked to a round', async () => {
+      await tokenAsContributor.approve(
+        fundingRound.address,
+        contributionAmount,
+      );
+      await expect(fundingRoundAsContributor.contribute(userPubKey, contributionAmount))
+        .to.be.revertedWith('FundingRound: MACI not deployed');
+    });
+
+    it('limits the number of contributors', async () => {
+      // TODO: add test later
+    });
+
+    it('rejects contributions if funding round has been finalized', async () => {
+      // TODO: add test later
+    });
+
+    it('rejects contributions with zero amount', async () => {
+      await fundingRound.setMaci(maci.address);
+      await tokenAsContributor.approve(
+        fundingRound.address,
+        contributionAmount,
+      );
+      await expect(fundingRoundAsContributor.contribute(userPubKey, 0))
+        .to.be.revertedWith('FundingRound: Contribution amount must be greater than zero');
+    });
+
+    it('allows to contribute only once per round', async () => {
+      await fundingRound.setMaci(maci.address);
+      await tokenAsContributor.approve(
+        fundingRound.address,
+        contributionAmount * 2,
+      );
+      await fundingRoundAsContributor.contribute(userPubKey, contributionAmount)
+      await expect(fundingRoundAsContributor.contribute(userPubKey, contributionAmount))
+        .to.be.revertedWith('FundingRound: Already contributed');
+    });
+
+    it('requires approval', async () => {
+      await fundingRound.setMaci(maci.address);
+      await expect(fundingRoundAsContributor.contribute(userPubKey, contributionAmount))
+        .to.be.revertedWith('revert ERC20: transfer amount exceeds allowance');
+    });
+  });
+
+  it('allows owner to finalize round', async () => {
+    // TODO: add tests later
+  });
+
+  it('allows recipient to claim funds', async () => {
+    // TODO: add tests later
+  });
+});

--- a/contracts/tests/utils.ts
+++ b/contracts/tests/utils.ts
@@ -1,5 +1,8 @@
+import { Contract, Event } from 'ethers';
 import { TransactionResponse } from 'ethers/providers';
 import { BigNumber } from 'ethers/utils/bignumber';
+
+export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 export async function getGasUsage(transaction: TransactionResponse): Promise<Number | null> {
   const receipt = await transaction.wait();
@@ -8,6 +11,22 @@ export async function getGasUsage(transaction: TransactionResponse): Promise<Num
   } else {
     return null;
   }
+}
+
+export async function getEventArg(
+  transaction: TransactionResponse,
+  contract: Contract,
+  eventName: string,
+  argumentName: string,
+): Promise<any> {
+  const receipt = await transaction.wait();
+  for (const log of receipt.logs || []) {
+    const event = contract.interface.parseLog(log);
+    if (event && event.name === eventName) {
+      return event.values[argumentName];
+    }
+  }
+  throw new Error('Event not found');
 }
 
 export class MaciParameters {

--- a/package.json
+++ b/package.json
@@ -15,17 +15,17 @@
   },
   "scripts": {
     "build": "yarn workspaces run build",
-    "build:contracts": "yarn workspace @my-app/contracts run build",
-    "build:web": "yarn workspace @my-app/vue-app run build",
+    "build:contracts": "yarn workspace @clrfund/contracts run build",
+    "build:web": "yarn workspace @clrfund/vue-app run build",
     "start:dev": "yarn deploy:local && yarn start:web",
-    "start:node": "yarn workspace @my-app/contracts run node",
-    "start:web": "yarn workspace @my-app/vue-app run serve",
+    "start:node": "yarn workspace @clrfund/contracts run node",
+    "start:web": "yarn workspace @clrfund/vue-app run serve",
     "test": "yarn workspaces run test",
-    "test:contracts": "yarn workspace @my-app/contracts run test",
-    "test:web": "yarn workspace @my-app/vue-app run test",
-    "deploy:local": "yarn workspace @my-app/contracts run deploy:local",
-    "upgrade:local": "yarn workspace @my-app/contracts run upgrade:local",
+    "test:contracts": "yarn workspace @clrfund/contracts run test",
+    "test:web": "yarn workspace @clrfund/vue-app run test",
+    "deploy:local": "yarn workspace @clrfund/contracts run deploy:local",
+    "upgrade:local": "yarn workspace @clrfund/contracts run upgrade:local",
     "lint": "yarn lint:web",
-    "lint:web": "yarn workspace @my-app/vue-app run lint"
+    "lint:web": "yarn workspace @clrfund/vue-app run lint"
   }
 }

--- a/vue-app/src/views/Home.vue
+++ b/vue-app/src/views/Home.vue
@@ -25,6 +25,15 @@ async function getCurrentRound() {
     provider
   );
   const fundingRoundAddress = await factory.getCurrentRound();
+
+  if (fundingRoundAddress === "0x0000000000000000000000000000000000000000") {
+    return {
+      fundingRoundAddress: "N/A",
+      nativeTokenAddress: "N/A",
+      contributions: []
+    };
+  }
+
   const fundingRound = new ethers.Contract(
     fundingRoundAddress,
     FundingRound.abi,


### PR DESCRIPTION
In this PR I'm implementing the scheme described in this diagram: https://github.com/clrfund/monorepo/issues/14#issuecomment-638685294.

- Factory contract now stores the history of all rounds, not just the current round and the one before it.
- Added method for making contributions to the matching pool: `FundingRoundFactory.contribute()`.
- The assumption here is that MACI deployment happens at the beginning of the round. But we can change that.
- Finalization of a funding round doesn't trigger deployment of a new round.
- All code related to funding round cancellation were temporarily removed. The plan is to re-implement it separately from this PR: https://github.com/clrfund/monorepo/issues/46.
- Resolves https://github.com/clrfund/monorepo/issues/18. Witness role were removed.
- Claiming of funds will be implemented later (https://github.com/clrfund/monorepo/issues/19).
- Resolves https://github.com/clrfund/monorepo/issues/27. There's no BrightID verification at the moment, everyone can contribute.
