### PR TITLE
Contracts: Assign indices to registered recipients

### DIFF
--- a/contracts/contracts/FundingRound.sol
+++ b/contracts/contracts/FundingRound.sol
@@ -1,15 +1,13 @@
 pragma solidity ^0.5.0;
 pragma experimental ABIEncoderV2;
 
-import '@nomiclabs/buidler/console.sol';
-
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/SafeERC20.sol';
 
 import 'maci/contracts/sol/MACI.sol';
 import 'maci/contracts/sol/MACIPubKey.sol';
 
-import './FundingRoundFactory.sol';
+import './IRecipientRegistry.sol';
 
 contract FundingRound is Ownable, MACIPubKey {
   using SafeERC20 for IERC20;
@@ -21,29 +19,31 @@ contract FundingRound is Ownable, MACIPubKey {
 
   PubKey public coordinatorPubKey;
   MACI public maci;
-  // ERC20 token being used
   IERC20 public nativeToken;
+  IRecipientRegistry public recipientRegistry;
 
   mapping(address => uint256) public contributors;
   
   event FundsClaimed(address _recipient);
   event NewContribution(address indexed _sender, uint256 _amount);
 
-
   /**
     * @dev Sets round parameters (they can only be set once during construction).
     * @param _nativeToken Address of a token which will be accepted for contributions.
+    * @param _recipientRegistry Address of the recipient registry.
     * @param _duration Duration of the contribution period in seconds.
     * @param _coordinatorPubKey Coordinator's public key.
     */
   constructor(
     IERC20 _nativeToken,
+    IRecipientRegistry _recipientRegistry,
     uint256 _duration,
     PubKey memory _coordinatorPubKey
   )
     public
   {
     nativeToken = _nativeToken;
+    recipientRegistry = _recipientRegistry;
     contributionDeadline = now + _duration;
     coordinatorPubKey = _coordinatorPubKey;
   }

--- a/contracts/contracts/FundingRoundFactory.sol
+++ b/contracts/contracts/FundingRoundFactory.sol
@@ -29,10 +29,11 @@ contract FundingRoundFactory is Ownable, MACIPubKey {
   FundingRound[] private rounds;
 
   mapping(address => string) public recipients;
+  mapping(address => uint256) public recipientIndex;
 
   // Events
   event NewContribution(address indexed _sender, uint256 _amount);
-  event RecipientAdded(address indexed _fundingAddress, string _name);
+  event RecipientAdded(address indexed _fundingAddress, string _name, uint256 _index);
   event NewToken(address _token);
   event NewRound(address _round);
   event CoordinatorTransferred(address _newCoordinator);
@@ -57,17 +58,25 @@ contract FundingRoundFactory is Ownable, MACIPubKey {
     emit NewContribution(msg.sender, _amount);
   }
 
+  /**
+    * @dev Register recipient as eligible for funding allocation.
+    * @param _fundingAddress The address that receives funds.
+    * @param _name The display name of the recipient.
+    */
   function addRecipient(address _fundingAddress, string memory _name)
     public
     onlyOwner
   {
+    // TODO: verify address and get recipient info from the recipient registry
     require(_fundingAddress != address(0), 'Factory: Recipient address is zero');
     require(bytes(_name).length != 0, 'Factory: Recipient name is empty string');
     require(bytes(recipients[_fundingAddress]).length == 0, 'Factory: Recipient already registered');
+    // TODO: implement mechanism for replacing registrants
     require(recipientCount < maciFactory.maxVoteOptions(), 'Factory: Recipient limit reached');
-    recipients[_fundingAddress] = _name;
     recipientCount += 1;
-    emit RecipientAdded(_fundingAddress, _name);
+    recipients[_fundingAddress] = _name;
+    recipientIndex[_fundingAddress] = recipientCount;  // Starts with 1
+    emit RecipientAdded(_fundingAddress, _name, recipientCount);
   }
 
   function getCurrentRound()

--- a/contracts/contracts/IRecipientRegistry.sol
+++ b/contracts/contracts/IRecipientRegistry.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+interface IRecipientRegistry {
+
+  function addRecipient(address _fundingAddress, string calldata _name) external;
+
+  function getRecipientIndex(address _recipient) external view returns (uint256);
+
+}

--- a/contracts/contracts/IRecipientRegistry.sol
+++ b/contracts/contracts/IRecipientRegistry.sol
@@ -1,6 +1,19 @@
 pragma solidity ^0.5.0;
 pragma experimental ABIEncoderV2;
 
+/**
+ * @dev Interface of the recipient registry.
+ *
+ * This contract must do the following:
+ *
+ * - Add recipients to the registry.
+ * - Allow only legitimate recipients into the registry.
+ * - Assign an unique index to each recipient.
+ * - Find the recipient's index by their address.
+ * - Limit the maximum number of entries according to MACI's maxVoteOptions.
+ * - (TODO) Remove invalid entries.
+ * - (TODO) Prevent indices from changing during the funding round.
+ */
 interface IRecipientRegistry {
 
   function addRecipient(address _fundingAddress, string calldata _name) external;

--- a/contracts/contracts/MACIFactory.sol
+++ b/contracts/contracts/MACIFactory.sol
@@ -19,12 +19,12 @@ contract MACIFactory is Ownable, MACIParameters {
   // State
   uint8 private stateTreeDepth = 10;
   uint8 private messageTreeDepth = 10;
-  uint8 private voteOptionTreeDepth = 4;
+  uint8 private voteOptionTreeDepth = 2;
   uint8 private tallyBatchSize = 4;
   uint8 private messageBatchSize = 4;
   uint256 public maxUsers = STATE_TREE_BASE ** 10 - 1;
   uint256 public maxMessages = MESSAGE_TREE_BASE ** 10 - 1;
-  uint256 public maxVoteOptions = VOTE_OPTION_TREE_BASE ** 4 - 1;
+  uint256 public maxVoteOptions = VOTE_OPTION_TREE_BASE ** 2 - 1;
   uint256 public signUpDuration = 7 * 86400;
   uint256 public votingDuration = 7 * 86400;
 
@@ -63,6 +63,10 @@ contract MACIFactory is Ownable, MACIParameters {
     public
     onlyOwner
   {
+    require(
+      _voteOptionTreeDepth >= voteOptionTreeDepth,
+      'MACIFactory: Vote option tree depth can not be decreased'
+    );
     stateTreeDepth = _stateTreeDepth;
     messageTreeDepth = _messageTreeDepth;
     voteOptionTreeDepth = _voteOptionTreeDepth;

--- a/contracts/tests/factory.ts
+++ b/contracts/tests/factory.ts
@@ -91,7 +91,7 @@ describe('Funding Round Factory', () => {
         .withArgs(fundingAddress, recipientName, expectedIndex);
       expect(await factory.recipients(fundingAddress))
         .to.equal(recipientName);
-      expect(await factory.recipientIndex(fundingAddress))
+      expect(await factory.getRecipientIndex(fundingAddress))
         .to.equal(expectedIndex);
     });
 

--- a/contracts/tests/factory.ts
+++ b/contracts/tests/factory.ts
@@ -13,14 +13,13 @@ use(solidity);
 
 describe('Funding Round Factory', () => {
   const provider = waffle.provider;
-  
   const [dontUseMe, deployer, coordinator, contributor] = provider.getWallets();// eslint-disable-line @typescript-eslint/no-unused-vars
 
   let maciFactory: Contract;
   let factory: Contract;
   let token: Contract;
 
-  let maciParameters = new MaciParameters();
+  const maciParameters = new MaciParameters();
   const coordinatorPubKey = { x: 0, y: 1 };
 
   beforeEach(async () => {
@@ -86,11 +85,14 @@ describe('Funding Round Factory', () => {
     });
 
     it('allows owner to add recipient', async () => {
+      const expectedIndex = 1;
       await expect(factory.addRecipient(fundingAddress, recipientName))
         .to.emit(factory, 'RecipientAdded')
-        .withArgs(fundingAddress, recipientName);
+        .withArgs(fundingAddress, recipientName, expectedIndex);
       expect(await factory.recipients(fundingAddress))
         .to.equal(recipientName);
+      expect(await factory.recipientIndex(fundingAddress))
+        .to.equal(expectedIndex);
     });
 
     it('rejects calls from anyone except owner', async () => {
@@ -119,11 +121,7 @@ describe('Funding Round Factory', () => {
     });
 
     it('should limit the number of recipients', async () => {
-      // Reduce number of vote options to speed up the test
-      maciParameters = new MaciParameters({ voteOptionTreeDepth: 1 });
-      await factory.setMaciParameters(...maciParameters.values());
-
-      const maxRecipientCount = 4;
+      const maxRecipientCount = 5 ** maciParameters.voteOptionTreeDepth - 1;
       for (let i = 0; i < maxRecipientCount + 1; i++) {
         recipientName = String(i + 1).padStart(4, '0');
         fundingAddress = `0x000000000000000000000000000000000000${recipientName}`;

--- a/contracts/tests/maciFactory.ts
+++ b/contracts/tests/maciFactory.ts
@@ -13,8 +13,7 @@ describe('MACI factory', () => {
   const [dontUseMe, deployer, coordinator] = provider.getWallets();// eslint-disable-line @typescript-eslint/no-unused-vars
 
   let maciFactory: Contract;
-
-  const maciParameters = new MaciParameters();
+  let maciParameters = new MaciParameters();
   const coordinatorPubKey = { x: 0, y: 1 };
 
   beforeEach(async () => {
@@ -25,12 +24,19 @@ describe('MACI factory', () => {
   it('sets default MACI parameters', async () => {
     expect(await maciFactory.maxUsers()).to.equal(1023);
     expect(await maciFactory.maxMessages()).to.equal(1023);
-    expect(await maciFactory.maxVoteOptions()).to.equal(624);
+    expect(await maciFactory.maxVoteOptions()).to.equal(24);
     expect(await maciFactory.signUpDuration()).to.equal(604800);
     expect(await maciFactory.votingDuration()).to.equal(604800);
   });
 
   it('sets MACI parameters', async () => {
+    maciParameters = new MaciParameters({
+      stateTreeDepth: 8,
+      messageTreeDepth: 12,
+      voteOptionTreeDepth: 4,
+      signUpDuration: 86400,
+      votingDuration: 86400,
+    });
     await expect(maciFactory.setMaciParameters(...maciParameters.values()))
       .to.emit(maciFactory, 'MaciParametersChanged');
 
@@ -44,6 +50,12 @@ describe('MACI factory', () => {
       .to.equal(maciParameters.signUpDuration);
     expect(await maciFactory.votingDuration())
       .to.equal(maciParameters.votingDuration);
+  });
+
+  it('does not allow to decrease the vote option tree depth', async () => {
+    maciParameters = new MaciParameters({ voteOptionTreeDepth: 1 });
+    await expect(maciFactory.setMaciParameters(...maciParameters.values()))
+      .to.be.revertedWith('MACIFactory: Vote option tree depth can not be decreased');
   });
 
   it('allows only owner to set MACI parameters', async () => {

--- a/contracts/tests/utils.ts
+++ b/contracts/tests/utils.ts
@@ -31,14 +31,14 @@ export async function getEventArg(
 
 export class MaciParameters {
 
-  // Defaults for tests
-  stateTreeDepth = 4;
-  messageTreeDepth = 4;
+  // Defaults
+  stateTreeDepth = 10;
+  messageTreeDepth = 10;
   voteOptionTreeDepth = 2;
-  tallyBatchSize = 2;
-  messageBatchSize = 2;
-  signUpDuration = 3600;
-  votingDuration = 3600;
+  tallyBatchSize = 4;
+  messageBatchSize = 4;
+  signUpDuration = 7 * 86400;
+  votingDuration = 7 * 86400;
 
   constructor(parameters: {[name: string]: number} = {}) {
     for (const [name, value] of Object.entries(parameters)) {


### PR DESCRIPTION
- Assigning index to each registered recipient with respect to max vote options in MACI (needed for #19).
- Introduced `RecipientRegistry` interface as a first step to pluggable recipient curation (#49).
- Decreasing of `voteOptionTreeDepth` parameter is now forbidden in order to prevent invalidation of vote option indices of registered recipients (see related discussion in #49).