### PR TITLE
Allow anyone to call claimFunds()

### DIFF
--- a/contracts/contracts/FundingRound.sol
+++ b/contracts/contracts/FundingRound.sol
@@ -266,6 +266,6 @@ contract FundingRound is Ownable, MACISharedObjs, SignUpGatekeeper, InitialVoice
     recipients[voteOptionIndex] = true;
     uint256 claimableAmount = matchingPoolSize * _tallyResult / totalVotes + _spent;
     nativeToken.transfer(_recipient, claimableAmount);
-    emit FundsClaimed(msg.sender, claimableAmount);
+    emit FundsClaimed(_recipient, claimableAmount);
   }
 }

--- a/contracts/contracts/FundingRound.sol
+++ b/contracts/contracts/FundingRound.sol
@@ -231,6 +231,7 @@ contract FundingRound is Ownable, MACISharedObjs, SignUpGatekeeper, InitialVoice
     * @param _spentSalt Salt.
     */
   function claimFunds(
+    address _recipient,
     uint256 _tallyResult,
     uint256[][] memory _tallyResultProof,
     uint256 _tallyResultSalt,
@@ -242,7 +243,7 @@ contract FundingRound is Ownable, MACISharedObjs, SignUpGatekeeper, InitialVoice
   {
     require(isFinalized, 'FundingRound: Round not finalized');
     require(!isCancelled, 'FundingRound: Round has been cancelled');
-    uint256 voteOptionIndex = recipientRegistry.getRecipientIndex(msg.sender);
+    uint256 voteOptionIndex = recipientRegistry.getRecipientIndex(_recipient);
     require(voteOptionIndex > 0, 'FundingRound: Invalid recipient address');
     require(!recipients[voteOptionIndex], 'FundingRound: Funds already claimed');
     (,, uint8 voteOptionTreeDepth) = maci.treeDepths();
@@ -264,7 +265,7 @@ contract FundingRound is Ownable, MACISharedObjs, SignUpGatekeeper, InitialVoice
     require(spentVerified, 'FundingRound: Incorrect amount of spent voice credits');
     recipients[voteOptionIndex] = true;
     uint256 claimableAmount = matchingPoolSize * _tallyResult / totalVotes + _spent;
-    nativeToken.transfer(msg.sender, claimableAmount);
+    nativeToken.transfer(_recipient, claimableAmount);
     emit FundsClaimed(msg.sender, claimableAmount);
   }
 }

--- a/contracts/scripts/claim.ts
+++ b/contracts/scripts/claim.ts
@@ -36,6 +36,7 @@ async function main() {
     }
     const spentProof = spentTree.genMerklePath(recipientIndex)
     const recipientClaimData = [
+      recipient.getAddress(),
       result,
       resultProof.pathElements.map((x) => x.map((y: SnarkBigInt) => y.toString())),
       resultSalt,

--- a/contracts/tests/round.ts
+++ b/contracts/tests/round.ts
@@ -557,7 +557,7 @@ describe('Funding Round', () => {
 
       await expect(fundingRoundAsContributor.claimFunds(...recipientClaimData))
         .to.emit(fundingRound, 'FundsClaimed')
-        .withArgs(contributor.address, expectedClaimableAmount);
+        .withArgs(recipient.address, expectedClaimableAmount);
       expect(await token.balanceOf(recipient.address))
         .to.equal(expectedClaimableAmount);
     });

--- a/contracts/tests/round.ts
+++ b/contracts/tests/round.ts
@@ -513,6 +513,7 @@ describe('Funding Round', () => {
     ];
     const expectedClaimableAmount = matchingPoolSize / 2 + totalSpent / 2;
     let fundingRoundAsRecipient: Contract;
+    let fundingRoundAsContributor: Contract;
 
     beforeEach(async () => {
       maci = await deployMaciMock()
@@ -530,7 +531,7 @@ describe('Funding Round', () => {
         fundingRound.address,
         totalSpent,
       );
-      const fundingRoundAsContributor = fundingRound.connect(contributor);
+      fundingRoundAsContributor = fundingRound.connect(contributor);
       await fundingRoundAsContributor.contribute(
         userKeypair.pubKey.asContractParam(),
         totalSpent,
@@ -546,6 +547,17 @@ describe('Funding Round', () => {
       await expect(fundingRoundAsRecipient.claimFunds(...recipientClaimData))
         .to.emit(fundingRound, 'FundsClaimed')
         .withArgs(recipient.address, expectedClaimableAmount);
+      expect(await token.balanceOf(recipient.address))
+        .to.equal(expectedClaimableAmount);
+    });
+
+    it('allows address different than recipient to claim allocated funds', async () => {
+      await token.transfer(fundingRound.address, matchingPoolSize);
+      await fundingRound.finalize(totalSpent, totalSpentSalt)
+
+      await expect(fundingRoundAsContributor.claimFunds(...recipientClaimData))
+        .to.emit(fundingRound, 'FundsClaimed')
+        .withArgs(contributor.address, expectedClaimableAmount);
       expect(await token.balanceOf(recipient.address))
         .to.equal(expectedClaimableAmount);
     });

--- a/contracts/tests/round.ts
+++ b/contracts/tests/round.ts
@@ -503,6 +503,7 @@ describe('Funding Round', () => {
     const totalVotes = 100; // Math.sqrt(totalSpent)
     const recipientIndex = 3;
     const recipientClaimData = [
+      recipient.address, // recipient
       totalVotes / 2, // Tally result
       [[0]], // Proof
       genRandomSalt().toString(),


### PR DESCRIPTION
Added new `address _recipient` parameter in `claimFunds()` and substituted `msg.sender` with it within this function to allow any address to reclaim it.