### PR TITLE
Removing recipients from registry

### DIFF
--- a/contracts/.solhint.json
+++ b/contracts/.solhint.json
@@ -3,6 +3,7 @@
   "rules": {
     "not-rely-on-time": "off",
     "quotes": ["error", "single"],
-    "reason-string": ["warn", {"maxLength": 64}]
+    "reason-string": ["warn", {"maxLength": 64}],
+    "max-states-count": ["warn", 16]
   }
 }

--- a/contracts/contracts/FundingRound.sol
+++ b/contracts/contracts/FundingRound.sol
@@ -27,6 +27,7 @@ contract FundingRound is Ownable, MACISharedObjs, SignUpGatekeeper, InitialVoice
   }
 
   // State
+  uint256 public startTimestamp;
   uint256 public voiceCreditFactor;
   uint256 public contributorCount;
   uint256 public contributionDeadline;
@@ -72,6 +73,7 @@ contract FundingRound is Ownable, MACISharedObjs, SignUpGatekeeper, InitialVoice
     voiceCreditFactor = voiceCreditFactor > 0 ? voiceCreditFactor : 1;
     verifiedUserRegistry = _verifiedUserRegistry;
     recipientRegistry = _recipientRegistry;
+    startTimestamp = now;
     contributionDeadline = now + _duration;
     coordinatorPubKey = _coordinatorPubKey;
   }
@@ -274,7 +276,7 @@ contract FundingRound is Ownable, MACISharedObjs, SignUpGatekeeper, InitialVoice
   {
     require(isFinalized, 'FundingRound: Round not finalized');
     require(!isCancelled, 'FundingRound: Round has been cancelled');
-    uint256 voteOptionIndex = recipientRegistry.getRecipientIndex(_recipient);
+    uint256 voteOptionIndex = recipientRegistry.getRecipientIndex(_recipient, startTimestamp);
     require(voteOptionIndex > 0, 'FundingRound: Invalid recipient address');
     require(!recipients[voteOptionIndex], 'FundingRound: Funds already claimed');
     (,, uint8 voteOptionTreeDepth) = maci.treeDepths();

--- a/contracts/contracts/IRecipientRegistry.sol
+++ b/contracts/contracts/IRecipientRegistry.sol
@@ -11,13 +11,15 @@ pragma experimental ABIEncoderV2;
  * - Assign an unique index to each recipient.
  * - Find the recipient's index by their address.
  * - Limit the maximum number of entries according to MACI's maxVoteOptions.
- * - (TODO) Remove invalid entries.
- * - (TODO) Prevent indices from changing during the funding round.
+ * - Remove invalid entries.
+ * - Prevent indices from changing during the funding round.
  */
 interface IRecipientRegistry {
 
-  function addRecipient(address _fundingAddress, string calldata _name) external;
+  function addRecipient(address _recipient, string calldata _name) external;
 
-  function getRecipientIndex(address _recipient) external view returns (uint256);
+  function removeRecipient(address _recipient) external;
+
+  function getRecipientIndex(address _recipient, uint256 _timestamp) external view returns (uint256);
 
 }

--- a/vue-app/src/api/projects.ts
+++ b/vue-app/src/api/projects.ts
@@ -15,7 +15,7 @@ function decodeRecipientAdded(event: Event): Project {
   const args = event.args as any // eslint-disable-line @typescript-eslint/no-explicit-any
   const metadata = JSON.parse(args._metadata)
   return {
-    address: args._fundingAddress,
+    address: args._recipient,
     name: metadata.name,
     description: metadata.description,
     imageUrl: `${ipfsGatewayUrl}${metadata.imageHash}`,


### PR DESCRIPTION
Added mechanism for removing recipients that preserves vote options during the funding round (https://github.com/clrfund/monorepo/issues/56#issuecomment-689884250). 

Resolves #56