### PR TITLE
Add BrightID Verified User Registry contract

### DIFF
--- a/contracts/contracts/verifiedUserRegistry/IVerifiedUserRegistry.sol
+++ b/contracts/contracts/verifiedUserRegistry/IVerifiedUserRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.8;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/contracts/contracts/verifiedUserRegistry/IVerifiedUserRegistry.sol
+++ b/contracts/contracts/verifiedUserRegistry/IVerifiedUserRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity ^0.5.17;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/contracts/contracts/verifiedUserRegistry/README.md
+++ b/contracts/contracts/verifiedUserRegistry/README.md
@@ -1,12 +1,9 @@
-## Description
+## Description 
 This is a contract to register verified users context ids by BrightID node's verification data, and be able to query a user verification.
 This contract consist of:
--  Set BrightID settings
-`function setSettings(bytes32 _context, address _verifier) external onlyOwner ();`
-- Check a user is verified or not
-`function isVerifiedUser(address _user) override external view returns (bool);`
-- Register a user by BrightID node's verification data
- `function register(bytes32 _context, address[] calldata _addrs, uint _timestamp, uint8 _v, bytes32 _r, bytes32 _s external ();`
+-  Set BrightID settings  <br />`function setSettings(bytes32 _context, address _verifier) external onlyOwner;`
+- Check a user is verified or not  <br />`function isVerifiedUser(address _user) override external view returns (bool);`
+- Register a user by BrightID node's verification data <br />`function register(bytes32 _context, address[] calldata _addrs, uint _timestamp, uint8 _v, bytes32 _r, bytes32 _s external;`
 
 ## Demonstration
 [Demo contract on the Rinkeby](https://rinkeby.etherscan.io/address/0xf99e2173db1f341a947ce9bd7779af2245309f91)
@@ -37,8 +34,9 @@ You can update the BrightID settings and test register [here](https://rinkeby.et
 
  ## Deploy contract
 This contract needs tow constructor arguments
-`context bytes32` BrightID context used for verifying users
-`verifier address` BrightID verifier address that signs BrightID verifications
+- `context bytes32` <br /> BrightID context used for verifying users.
+
+- `verifier address` <br /> BrightID verifier address that signs BrightID verifications.
 
 ## Points
 We can simply use an ERC20 token as authorization for the verifiers to be able have multiple verifiers.

--- a/contracts/contracts/verifiedUserRegistry/README.md
+++ b/contracts/contracts/verifiedUserRegistry/README.md
@@ -1,0 +1,44 @@
+## Description
+This is a contract to register verified users context ids by BrightID node's verification data, and be able to query a user verification.
+This contract consist of:
+-  Set BrightID settings
+`function setSettings(bytes32 _context, address _verifier) external onlyOwner ();`
+- Check a user is verified or not
+`function isVerifiedUser(address _user) override external view returns (bool);`
+- Register a user by BrightID node's verification data
+ `function register(bytes32 _context, address[] calldata _addrs, uint _timestamp, uint8 _v, bytes32 _r, bytes32 _s external ();`
+
+## Demonstration
+[Demo contract on the Rinkeby](https://rinkeby.etherscan.io/address/0xf99e2173db1f341a947ce9bd7779af2245309f91)
+Sample of Registered Data:
+```
+{
+  "data": {
+    "unique": true,
+    "context": "clr.fund",
+    "contextIds": [
+      "0xb1775295f3b250c2849366801149479471fa7362",
+      "0x9ed6d9086f5ee9edc14dd2caca44d65ee8cabdde",
+      "0x79af508c9698076bc1c2dfa224f7829e9768b11e"
+    ],
+    "sig": {
+      "r": "ec6a9c3e10f238acb757ceea5507cf33366acd05356d513ca80cd1148297d079",
+      "s": "0e918c709ea7a458f7c95769145f475df94c01f3bc9e9ededf38153aa5b9041b",
+      "v": 28
+    },
+    "timestamp": 1602353670884,
+    "publicKey": "03ab573225151072be57d4808861e0f706595fb143c71630e188051fe4a6bda594"
+  }
+}
+```
+You can see the contract settings [here](https://rinkeby.etherscan.io/address/0xf99e2173db1f341a947ce9bd7779af2245309f91#readContract)
+
+You can update the BrightID settings and test register [here](https://rinkeby.etherscan.io/address/0xf99e2173db1f341a947ce9bd7779af2245309f91#writeContract)
+
+ ## Deploy contract
+This contract needs tow constructor arguments
+`context bytes32` BrightID context used for verifying users
+`verifier address` BrightID verifier address that signs BrightID verifications
+
+## Points
+We can simply use an ERC20 token as authorization for the verifiers to be able have multiple verifiers.

--- a/contracts/contracts/verifiedUserRegistry/VerifiedUserRegistry.sol
+++ b/contracts/contracts/verifiedUserRegistry/VerifiedUserRegistry.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.17;
 
 import "./IVerifiedUserRegistry.sol";
-import "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/ownership/Ownable.sol";
 
 contract VerifiedUserRegistry is Ownable, IVerifiedUserRegistry {
     string private constant ERROR_NEWER_VERIFICATION = "NEWER VERIFICATION REGISTERED BEFORE";

--- a/contracts/contracts/verifiedUserRegistry/VerifiedUserRegistry.sol
+++ b/contracts/contracts/verifiedUserRegistry/VerifiedUserRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity ^0.5.17;
 
 import "./IVerifiedUserRegistry.sol";
 import "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol";

--- a/contracts/contracts/verifiedUserRegistry/VerifiedUserRegistry.sol
+++ b/contracts/contracts/verifiedUserRegistry/VerifiedUserRegistry.sol
@@ -1,0 +1,91 @@
+pragma solidity ^0.6.0;
+
+import "./IVerifiedUserRegistry.sol";
+import "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol";
+
+contract VerifiedUserRegistry is Ownable, IVerifiedUserRegistry {
+    string private constant ERROR_NEWER_VERIFICATION = "NEWER VERIFICATION REGISTERED BEFORE";
+    string private constant ERROR_NOT_AUTHORIZED = "NOT AUTHORIZED";
+    string private constant ERROR_INVALID_VERIFIER = "INVALID VERIFIER";
+    string private constant ERROR_INVALID_CONTEXT = "INVALID CONTEXT";
+
+    bytes32 public context;
+    address public verifier;
+
+    struct Verification {
+        uint256 time;
+        bool isVerified;
+    }
+    mapping(address => Verification) public verifications;
+
+    event SetBrightIdSettings(bytes32 context, address verifier);
+
+    /**
+     * @param _context BrightID context used for verifying users
+     * @param _verifier BrightID verifier address that signs BrightID verifications
+     */
+    constructor(bytes32 _context, address _verifier) public {
+        // ecrecover returns zero on error
+        require(_verifier != address(0), ERROR_INVALID_VERIFIER);
+
+        context = _context;
+        verifier = _verifier;
+    }
+
+    /**
+     * @notice Set BrightID settings
+     * @param _context BrightID context used for verifying users
+     * @param _verifier BrightID verifier address that signs BrightID verifications
+     */
+    function setSettings(bytes32 _context, address _verifier) external onlyOwner {
+        // ecrecover returns zero on error
+        require(_verifier != address(0), ERROR_INVALID_VERIFIER);
+
+        context = _context;
+        verifier = _verifier;
+        emit SetBrightIdSettings(_context, _verifier);
+    }
+
+    /**
+     * @notice Check a user is verified or not
+     * @param _user BrightID context id used for verifying users
+     */
+    function isVerifiedUser(address _user) override external view returns (bool) {
+        return verifications[_user].isVerified;
+    }
+
+
+    /**
+     * @notice Register a user by BrightID verification
+     * @param _context The context used in the users verification
+     * @param _addrs The history of addresses used by this user in this context
+     * @param _timestamp The BrightID node's verification timestamp
+     * @param _v Component of signature
+     * @param _r Component of signature
+     * @param _s Component of signature
+     */
+    function register(
+        bytes32 _context,
+        address[] calldata _addrs,
+        uint _timestamp,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) external {
+        require(context == _context, ERROR_INVALID_CONTEXT);
+        require(verifications[_addrs[0]].time < _timestamp, ERROR_NEWER_VERIFICATION);
+
+        bytes32 message = keccak256(abi.encodePacked(_context, _addrs, _timestamp));
+        address signer = ecrecover(message, _v, _r, _s);
+        require(verifier == signer, ERROR_NOT_AUTHORIZED);
+
+        verifications[_addrs[0]].time = _timestamp;
+        verifications[_addrs[0]].isVerified = true;
+        for(uint i = 1; i < _addrs.length; i++) {
+            // update time of all previous context ids to be sure no one can use old verifications again
+            verifications[_addrs[i]].time = _timestamp;
+            // set old verifications unverified
+            verifications[_addrs[i]].isVerified = false;
+        }
+    }
+}

--- a/contracts/contracts/verifiedUserRegistry/VerifiedUserRegistry.sol
+++ b/contracts/contracts/verifiedUserRegistry/VerifiedUserRegistry.sol
@@ -59,7 +59,7 @@ contract VerifiedUserRegistry is Ownable, IVerifiedUserRegistry {
      * @notice Check a user is verified or not
      * @param _user BrightID context id used for verifying users
      */
-    function isVerifiedUser(address _user) override external view returns (bool) {
+    function isVerifiedUser(address _user) external view returns (bool) {
         return verifications[_user].isVerified;
     }
 

--- a/contracts/contracts/verifiedUserRegistry/VerifiedUserRegistry.sol
+++ b/contracts/contracts/verifiedUserRegistry/VerifiedUserRegistry.sol
@@ -19,6 +19,7 @@ contract VerifiedUserRegistry is Ownable, IVerifiedUserRegistry {
     mapping(address => Verification) public verifications;
 
     event SetBrightIdSettings(bytes32 context, address verifier);
+    event Sponsor(address addr);
 
     /**
      * @param _context BrightID context used for verifying users
@@ -30,6 +31,14 @@ contract VerifiedUserRegistry is Ownable, IVerifiedUserRegistry {
 
         context = _context;
         verifier = _verifier;
+    }
+
+    /**
+     * @notice Sponsor a BrightID user by context id
+     * @param addr BrightID context id
+     */
+    function sponsor(address addr) public {
+        emit Sponsor(addr);
     }
 
     /**


### PR DESCRIPTION
This is a contract to register verified users context ids by BrightID node's verification data, and be able to query a user verification