### PR TITLE
Contracts: Add tests for direct token transfers

### DIFF
--- a/contracts/tests/factory.ts
+++ b/contracts/tests/factory.ts
@@ -88,6 +88,15 @@ describe('Funding Round Factory', () => {
       await expect(factoryAsContributor.contributeMatchingFunds(contributionAmount))
         .to.be.revertedWith('revert ERC20: transfer amount exceeds allowance');
     });
+
+    it('accepts direct token transfer', async () => {
+      await factory.setToken(token.address)
+      const tokenAsContributor = token.connect(contributor)
+      await expect(tokenAsContributor.transfer(factory.address, contributionAmount))
+        .to.emit(token, 'Transfer')
+        .withArgs(contributor.address, factory.address, contributionAmount)
+      expect(await token.balanceOf(factory.address)).to.equal(contributionAmount)
+    })
   });
 
   describe('managing recipients', () => {


### PR DESCRIPTION
Resolves #167

Token transfers are already correctly handled by contracts. I added some tests to ensure it will work in the future.