### PR TITLE
Send funds allocated to invalid recipients back to the matching pool

### DIFF
--- a/contracts/contracts/FundingRound.sol
+++ b/contracts/contracts/FundingRound.sol
@@ -302,23 +302,25 @@ contract FundingRound is Ownable, MACISharedObjs, SignUpGatekeeper, InitialVoice
     );
     require(voteOptionIndex > 0, 'FundingRound: Invalid recipient address');
     require(!recipients[voteOptionIndex], 'FundingRound: Funds already claimed');
-    (,, uint8 voteOptionTreeDepth) = maci.treeDepths();
-    bool resultVerified = maci.verifyTallyResult(
-      voteOptionTreeDepth,
-      voteOptionIndex,
-      _tallyResult,
-      _tallyResultProof,
-      _tallyResultSalt
-    );
-    require(resultVerified, 'FundingRound: Incorrect tally result');
-    bool spentVerified = maci.verifyPerVOSpentVoiceCredits(
-      voteOptionTreeDepth,
-      voteOptionIndex,
-      _spent,
-      _spentProof,
-      _spentSalt
-    );
-    require(spentVerified, 'FundingRound: Incorrect amount of spent voice credits');
+    { // create scope to avoid 'stack too deep' error
+      (,, uint8 voteOptionTreeDepth) = maci.treeDepths();
+      bool resultVerified = maci.verifyTallyResult(
+        voteOptionTreeDepth,
+        voteOptionIndex,
+        _tallyResult,
+        _tallyResultProof,
+        _tallyResultSalt
+      );
+      require(resultVerified, 'FundingRound: Incorrect tally result');
+      bool spentVerified = maci.verifyPerVOSpentVoiceCredits(
+        voteOptionTreeDepth,
+        voteOptionIndex,
+        _spent,
+        _spentProof,
+        _spentSalt
+      );
+      require(spentVerified, 'FundingRound: Incorrect amount of spent voice credits');
+    }
     recipients[voteOptionIndex] = true;
     uint256 allocatedAmount = getAllocatedAmount(_tallyResult, _spent);
     nativeToken.safeTransfer(_recipient, allocatedAmount);

--- a/contracts/contracts/FundingRound.sol
+++ b/contracts/contracts/FundingRound.sol
@@ -322,7 +322,10 @@ contract FundingRound is Ownable, MACISharedObjs, SignUpGatekeeper, InitialVoice
       // TODO: use block numbers in MACI
       startBlock + (maci.signUpDurationSeconds() + maci.votingDurationSeconds()) / 15
     );
-    require(recipient != address(0), 'FundingRound: Invalid recipient index');
+    if (recipient == address(0)) {
+      // Send funds back to the matching pool
+      recipient = owner();
+    }
     uint256 allocatedAmount = getAllocatedAmount(_tallyResult, _spent);
     nativeToken.safeTransfer(recipient, allocatedAmount);
     emit FundsClaimed(_voteOptionIndex, recipient, allocatedAmount);

--- a/contracts/contracts/recipientRegistry/IRecipientRegistry.sol
+++ b/contracts/contracts/recipientRegistry/IRecipientRegistry.sol
@@ -10,18 +10,15 @@ pragma solidity ^0.6.12;
  * - Add recipients to the registry.
  * - Allow only legitimate recipients into the registry.
  * - Assign an unique index to each recipient.
- * - Find the recipient's index by their address.
  * - Limit the maximum number of entries according to a parameter set by the funding round factory.
  * - Remove invalid entries.
  * - Prevent indices from changing during the funding round.
+ * - Find address of a recipient by their unique index.
  */
 interface IRecipientRegistry {
 
-  event RecipientAdded(address indexed _recipient, string _metadata, uint256 _index);
-  event RecipientRemoved(address indexed _recipient);
-
   function setMaxRecipients(uint256 _maxRecipients) external returns (bool);
 
-  function getRecipientIndex(address _recipient, uint256 _startBlock, uint256 _endBlock) external view returns (uint256);
+  function getRecipientAddress(uint256 _index, uint256 _startBlock, uint256 _endBlock) external view returns (address);
 
 }

--- a/contracts/contracts/recipientRegistry/SimpleRecipientRegistry.sol
+++ b/contracts/contracts/recipientRegistry/SimpleRecipientRegistry.sol
@@ -16,15 +16,16 @@ contract SimpleRecipientRegistry is Ownable, IRecipientRegistry {
     uint256 index;
     uint256 addedAt;
     uint256 removedAt;
-    uint256 prevRemovedAt;
   }
 
   // State
   address public controller;
   uint256 public maxRecipients;
-  uint256 private nextRecipientIndex = 1;
   mapping(address => Recipient) private recipients;
   address[] private removed;
+  // Slot 0 corresponds to index 1
+  // Each slot contains a history of recipients who occupied it
+  address[][] private slots;
 
   // Events
   event RecipientAdded(address indexed _recipient, string _metadata, uint256 _index);
@@ -82,20 +83,22 @@ contract SimpleRecipientRegistry is Ownable, IRecipientRegistry {
     require(bytes(_metadata).length != 0, 'RecipientRegistry: Metadata info is empty string');
     require(recipients[_recipient].index == 0, 'RecipientRegistry: Recipient already registered');
     uint256 recipientIndex = 0;
-    uint256 prevRemovedAt = 0;
+    uint256 nextRecipientIndex = slots.length + 1;
     if (nextRecipientIndex <= maxRecipients) {
       // Assign next index in sequence
       recipientIndex = nextRecipientIndex;
-      nextRecipientIndex += 1;
+      address[] memory history = new address[](1);
+      history[0] = _recipient;
+      slots.push(history);
     } else {
       // Assign one of the vacant recipient indexes
       require(removed.length > 0, 'RecipientRegistry: Recipient limit reached');
-      Recipient memory removedRecipient = recipients[removed[removed.length - 1]];
+      address removedRecipient = removed[removed.length - 1];
       removed.pop();
-      recipientIndex = removedRecipient.index;
-      prevRemovedAt = removedRecipient.removedAt;
+      recipientIndex = recipients[removedRecipient].index;
+      slots[recipientIndex - 1].push(_recipient);
     }
-    recipients[_recipient] = Recipient(recipientIndex, block.number, 0, prevRemovedAt);
+    recipients[_recipient] = Recipient(recipientIndex, block.number, 0);
     emit RecipientAdded(_recipient, _metadata, recipientIndex);
   }
 
@@ -134,15 +137,29 @@ contract SimpleRecipientRegistry is Ownable, IRecipientRegistry {
     if (
       recipient.index == 0 ||
       recipient.addedAt > _endBlock ||
-      recipient.removedAt != 0 && recipient.removedAt <= _startBlock ||
-      recipient.prevRemovedAt > _startBlock
+      recipient.removedAt != 0 && recipient.removedAt <= _startBlock
     ) {
       // Return 0 if recipient is not in the registry
       // or added after the end of the funding round
       // or had been already removed when the round started
-      // or inherits index from removed recipient who participates in the round
       return 0;
     } else {
+      address[] memory history = slots[recipient.index - 1];
+      // Check recipients who also occupied this slot
+      for (uint256 idx = history.length; idx > 0; idx--) {
+        address prevRecipient = history[idx - 1];
+        if (prevRecipient == _recipient) {
+          continue;
+        }
+        if (recipients[prevRecipient].removedAt > _startBlock) {
+          // Previous recipient still participates in the round
+          return 0;
+        } else {
+          // Stop search because subsequent items were removed
+          // before than the beginning of the round
+          break;
+        }
+      }
       return recipient.index;
     }
   }

--- a/contracts/e2e/index.ts
+++ b/contracts/e2e/index.ts
@@ -206,9 +206,7 @@ describe('End-to-end Tests', function () {
     const recipientTreeDepth = (await maci.treeDepths()).voteOptionTreeDepth
     for (const recipientIndex of [1, 2]) {
       const recipient = recipientIndex === 1 ? recipient1 : recipient2
-      const recipientAddress = await recipient.getAddress()
       const recipientClaimData = getRecipientClaimData(
-        recipientAddress,
         recipientIndex,
         recipientTreeDepth,
         tally,

--- a/contracts/scripts/claim.ts
+++ b/contracts/scripts/claim.ts
@@ -19,7 +19,6 @@ async function main() {
   for (const recipientIndex of [1, 2]) {
     const recipient = recipientIndex === 1 ? recipient1 : recipient2
     const recipientClaimData = getRecipientClaimData(
-      await recipient.getAddress(),
       recipientIndex,
       recipientTreeDepth,
       tally,

--- a/contracts/tests/round.ts
+++ b/contracts/tests/round.ts
@@ -783,11 +783,12 @@ describe('Funding Round', () => {
       await fundingRound.finalize(totalSpent, totalSpentSalt)
       await recipientRegistry.mock.getRecipientAddress.returns(ZERO_ADDRESS)
 
+      const initialDeployerBalance = await token.balanceOf(deployer.address)
       await expect(fundingRoundAsRecipient.claimFunds(...recipientClaimData))
         .to.emit(fundingRound, 'FundsClaimed')
         .withArgs(recipientIndex, deployer.address, expectedAllocatedAmount)
       expect(await token.balanceOf(deployer.address))
-        .to.equal(expectedAllocatedAmount)
+        .to.equal(initialDeployerBalance.add(expectedAllocatedAmount))
     });
 
     it('allows recipient to claim allocated funds only once', async () => {

--- a/contracts/utils/maci.ts
+++ b/contracts/utils/maci.ts
@@ -107,7 +107,6 @@ export function createMessage(
 }
 
 export function getRecipientClaimData(
-  recipientAddress: string,
   recipientIndex: number,
   recipientTreeDepth: number,
   tally: any,
@@ -130,7 +129,7 @@ export function getRecipientClaimData(
   const spentProof = spentTree.genMerklePath(recipientIndex)
 
   return [
-    recipientAddress,
+    recipientIndex,
     result,
     resultProof.pathElements.map((x) => x.map((y) => y.toString())),
     resultSalt,

--- a/vue-app/src/api/abi.ts
+++ b/vue-app/src/api/abi.ts
@@ -4,7 +4,7 @@ import { abi as FundingRound } from '../../../contracts/build/contracts/FundingR
 import { abi as MACI } from '../../../contracts/build/contracts/MACI.json'
 import { abi as VerifiedUserRegistry } from '../../../contracts/build/contracts/IVerifiedUserRegistry.json'
 import { abi as BrightIdUserRegistry } from '../../../contracts/build/contracts/BrightIdUserRegistry.json'
-import { abi as RecipientRegistry } from '../../../contracts/build/contracts/IRecipientRegistry.json'
+import { abi as RecipientRegistry } from '../../../contracts/build/contracts/SimpleRecipientRegistry.json'
 
 export {
   ERC20,

--- a/vue-app/src/api/claims.ts
+++ b/vue-app/src/api/claims.ts
@@ -19,10 +19,10 @@ export async function getAllocatedAmount(
 
 export async function isFundsClaimed(
   fundingRoundAddress: string,
-  recipientAddress: string,
+  recipientIndex: number,
 ): Promise<boolean> {
   const fundingRound = new Contract(fundingRoundAddress, FundingRound, provider)
-  const eventFilter = fundingRound.filters.FundsClaimed(recipientAddress)
+  const eventFilter = fundingRound.filters.FundsClaimed(recipientIndex)
   const events = await fundingRound.queryFilter(eventFilter, 0)
   return events.length > 0
 }

--- a/vue-app/src/api/projects.ts
+++ b/vue-app/src/api/projects.ts
@@ -14,7 +14,7 @@ export interface Project {
 }
 
 function decodeRecipientAdded(event: Event): Project {
-  const args = event.args as any // eslint-disable-line @typescript-eslint/no-explicit-any
+  const args = event.args as any
   const metadata = JSON.parse(args._metadata)
   return {
     address: args._recipient,

--- a/vue-app/src/components/ClaimModal.vue
+++ b/vue-app/src/components/ClaimModal.vue
@@ -57,7 +57,6 @@ export default class ClaimModal extends Vue {
     const { fundingRoundAddress, recipientTreeDepth, nativeTokenDecimals } = this.currentRound
     const fundingRound = new Contract(fundingRoundAddress, FundingRound, signer)
     const recipientClaimData = getRecipientClaimData(
-      this.project.address,
       this.project.index,
       recipientTreeDepth,
       this.$store.state.tally,

--- a/vue-app/src/utils/maci.ts
+++ b/vue-app/src/utils/maci.ts
@@ -69,7 +69,6 @@ export interface Tally {
 }
 
 export function getRecipientClaimData(
-  recipientAddress: string,
   recipientIndex: number,
   recipientTreeDepth: number,
   tally: Tally,
@@ -92,7 +91,7 @@ export function getRecipientClaimData(
   const spentProof = spentTree.genMerklePath(recipientIndex)
 
   return [
-    recipientAddress,
+    recipientIndex,
     result,
     resultProof.pathElements.map((x) => x.map((y) => y.toString())),
     resultSalt,

--- a/vue-app/src/views/Project.vue
+++ b/vue-app/src/views/Project.vue
@@ -75,7 +75,7 @@ export default class ProjectView extends Vue {
     )
     this.claimed = await isFundsClaimed(
       currentRound.fundingRoundAddress,
-      this.project.address,
+      this.project.index,
     )
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4217,6 +4217,14 @@ circom@0.5.27:
     tmp-promise "^2.0.2"
     wasmbuilder "0.0.10"
 
+circom_runtime@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/circom_runtime/-/circom_runtime-0.0.6.tgz#ef20ed273f03a5fdd699fd889b01feb9e13ada44"
+  integrity sha512-o0T5MuWzxnxinWG3+CygS/kZouoP+z5ZrufUwqKJy3gsVFJhkbqMpfKmcBGjhExB3uatA7cKyOiRAOLOz5+t5w==
+  dependencies:
+    ffjavascript "0.1.0"
+    fnv-plus "^1.3.1"
+
 circom_runtime@0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/circom_runtime/-/circom_runtime-0.1.4.tgz#eb8802f8743224ee603f70894b6f107d225463e4"
@@ -6542,9 +6550,17 @@ ethereumjs-abi@0.6.7:
     bn.js "^4.11.8"
     ethereumjs-util "^6.0.0"
 
-ethereumjs-abi@^0.6.8, "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
+ethereumjs-abi@^0.6.8:
   version "0.6.8"
-  resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b"
+  resolved "https://registry.yarnpkg.com/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz#71bc152db099f70e62f108b7cdfca1b362c6fcae"
+  integrity sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==
+  dependencies:
+    bn.js "^4.11.8"
+    ethereumjs-util "^6.0.0"
+
+"ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
+  version "0.6.8"
+  resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f"
   dependencies:
     bn.js "^4.11.8"
     ethereumjs-util "^6.0.0"
@@ -7131,6 +7147,11 @@ fast-write-atomic@^0.2.0, fast-write-atomic@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fast-write-atomic/-/fast-write-atomic-0.2.1.tgz#7ee8ef0ce3c1f531043c09ae8e5143361ab17ede"
   integrity sha512-WvJe06IfNYlr+6cO3uQkdKdy3Cb1LlCJSF8zRs2eT8yuhdbSlR9nIt+TgQ92RUxiRrQm+/S7RARnMfCs5iuAjw==
+
+fastfile@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/fastfile/-/fastfile-0.0.1.tgz#bf12427f476d32220c45d890529df00347a61eb1"
+  integrity sha512-Fk8PWafGWGEUw7oPq/dJen92ASxknCEy4ZC8n4VEvSwCp/jcReyEmVoWsRIWTf+IvAp2MzvFi54vOPeK2LQZtQ==
 
 fastfile@0.0.12:
   version "0.0.12"
@@ -14892,6 +14913,14 @@ r1csfile@0.0.14:
     fastfile "0.0.7"
     ffjavascript "0.2.4"
 
+r1csfile@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/r1csfile/-/r1csfile-0.0.5.tgz#63e2a74f833693356f18d517b9fc42238df7e187"
+  integrity sha512-B+BdKPb/WUTp4N/3X4d1Spgx9Ojx5tFVejGZRJxpTtzq34mC8Vi/czWfiPj85V8kud31lCfYcZ16z7+czvM0Sw==
+  dependencies:
+    fastfile "0.0.1"
+    ffjavascript "0.1.0"
+
 rabin-wasm@^0.1.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/rabin-wasm/-/rabin-wasm-0.1.4.tgz#062310686acfc9e05c13c7156a2339af148c78f2"
@@ -15999,9 +16028,10 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-snarkjs@0.1.20, snarkjs@^0.1.20:
+snarkjs@0.1.20:
   version "0.1.20"
-  resolved "https://github.com/weijiekoh/snarkjs.git#52e0ceba0256bc9bf94cbc9500139dfc37018f91"
+  resolved "https://registry.yarnpkg.com/snarkjs/-/snarkjs-0.1.20.tgz#4284217e823e71d9c7ded01eb439ace5190b90e1"
+  integrity sha512-tYmWiVm1sZiB44aIh5w/3HUaTntTUC4fv+CWs4rR0gfkt2KbHTpArOqZW++/Lxujrn9IypXVhdKVUr/eE6Hxfg==
   dependencies:
     big-integer "^1.6.43"
     chai "^4.2.0"
@@ -16021,6 +16051,19 @@ snarkjs@0.3.23:
     ffjavascript "0.2.10"
     logplease "^1.2.15"
     r1csfile "0.0.12"
+
+snarkjs@^0.1.20:
+  version "0.1.31"
+  resolved "https://registry.yarnpkg.com/snarkjs/-/snarkjs-0.1.31.tgz#a9cf6982c2aa4b1b0da224a339c6370accda4041"
+  integrity sha512-Xu9Ai89GPLUI6hSyVkc6LRE3sUEje7+eokHeKkb4sZuWW4JqPKWRW7ZtwM7VjsisgVM2gVAg9IYsMD4k+MhuPA==
+  dependencies:
+    chai "^4.2.0"
+    circom_runtime "0.0.6"
+    escape-string-regexp "^1.0.5"
+    ffjavascript "0.1.0"
+    keccak "^3.0.0"
+    r1csfile "0.0.5"
+    yargs "^12.0.5"
 
 socket.io-adapter@~1.1.0:
   version "1.1.2"


### PR DESCRIPTION
Resolves #174. Recipients in funding round contract are now identified by their index instead of address. This prevents locking of funds in case someone voted for an invalid recipient.

This also allows recipient registry to use arbitrary identifier instead of address to identify recipients. Resolves #200. Supersedes #204.