### PR TITLE
Optimistic recipient registry contract

### DIFF
--- a/contracts/.solhint.json
+++ b/contracts/.solhint.json
@@ -5,6 +5,7 @@
     "not-rely-on-time": "off",
     "quotes": ["error", "single"],
     "reason-string": ["warn", {"maxLength": 64}],
-    "max-states-count": ["warn", 18]
+    "max-states-count": ["warn", 18],
+    "check-send-result": "off"
   }
 }

--- a/contracts/contracts/recipientRegistry/OptimisticRecipientRegistry.sol
+++ b/contracts/contracts/recipientRegistry/OptimisticRecipientRegistry.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.6.12;
+
+import '@openzeppelin/contracts/access/Ownable.sol';
+
+import './BaseRecipientRegistry.sol';
+
+/**
+ * @dev Recipient registry with optimistic execution of registrations and removals.
+ */
+contract OptimisticRecipientRegistry is Ownable, BaseRecipientRegistry {
+
+  // Structs
+  struct Request {
+    address payable requester;
+    uint256 submissionTime;
+    address recipientAddress; // Undefined in removal requests
+    string recipientMetadata;
+  }
+
+  // State
+  uint256 public baseDeposit;
+  uint256 public challengePeriodDuration;
+  mapping(bytes32 => Request) private requests;
+
+  // Events
+  event RequestSubmitted(bytes32 indexed _recipientId, address _recipient, string _metadata);
+  event RequestRejected(bytes32 indexed _recipientId);
+  event RecipientAdded(bytes32 indexed _recipientId, address _recipient, string _metadata, uint256 _index);
+  event RecipientRemoved(bytes32 indexed _recipientId);
+
+  /**
+    * @dev Deploy the registry.
+    * @param _baseDeposit Deposit required to add or remove item.
+    * @param _challengePeriodDuration The time owner has to challenge a request (seconds).
+    * @param _controller Controller address. Normally it's a funding round factory contract.
+    */
+  constructor(
+    uint256 _baseDeposit,
+    uint256 _challengePeriodDuration,
+    address _controller
+  )
+    public
+  {
+    baseDeposit = _baseDeposit;
+    challengePeriodDuration = _challengePeriodDuration;
+    controller = _controller;
+  }
+
+  /**
+    * @dev Submit recipient registration request.
+    * @param _recipient The address that receives funds.
+    * @param _metadata The metadata info of the recipient.
+    */
+  function addRecipient(address _recipient, string calldata _metadata)
+    external
+    payable
+  {
+    require(_recipient != address(0), 'RecipientRegistry: Recipient address is zero');
+    require(bytes(_metadata).length != 0, 'RecipientRegistry: Metadata info is empty string');
+    bytes32 recipientId = keccak256(abi.encodePacked(_recipient, _metadata));
+    require(recipients[recipientId].index == 0, 'RecipientRegistry: Recipient already registered');
+    require(requests[recipientId].submissionTime == 0, 'RecipientRegistry: Request already submitted');
+    require(msg.value == baseDeposit, 'RecipientRegistry: Incorrect deposit amount');
+    requests[recipientId] = Request(
+      msg.sender,
+      block.timestamp,
+      _recipient,
+      _metadata
+    );
+    emit RequestSubmitted(recipientId, _recipient, _metadata);
+  }
+
+  /**
+    * @dev Submit recipient removal request.
+    * @param _recipientId The ID of recipient.
+    */
+  function removeRecipient(bytes32 _recipientId)
+    external
+    payable
+  {
+    require(recipients[_recipientId].index != 0, 'RecipientRegistry: Recipient is not in the registry');
+    require(recipients[_recipientId].removedAt == 0, 'RecipientRegistry: Recipient already removed');
+    require(requests[_recipientId].submissionTime == 0, 'RecipientRegistry: Request already submitted');
+    require(msg.value == baseDeposit, 'RecipientRegistry: Incorrect deposit amount');
+    requests[_recipientId] = Request(
+      msg.sender,
+      block.timestamp,
+      address(0),
+      ''
+    );
+    emit RequestSubmitted(_recipientId, address(0), '');
+  }
+
+  /**
+    * @dev Reject request.
+    * @param _recipientId The ID of recipient.
+    */
+  function challengeRequest(bytes32 _recipientId)
+    external
+    onlyOwner
+    returns (bool)
+  {
+    Request memory request = requests[_recipientId];
+    require(request.submissionTime != 0, 'RecipientRegistry: Request does not exist');
+    address payable challenger = payable(owner());
+    bool isSent = challenger.send(baseDeposit);
+    delete requests[_recipientId];
+    emit RequestRejected(_recipientId);
+    return isSent;
+  }
+
+  /**
+    * @dev Execute request.
+    * @param _recipientId The ID of recipient.
+    */
+  function executeRequest(bytes32 _recipientId)
+    external
+    returns (bool)
+  {
+    Request memory request = requests[_recipientId];
+    require(request.submissionTime != 0, 'RecipientRegistry: Request does not exist');
+    require(
+      block.timestamp - request.submissionTime >= challengePeriodDuration,
+      'RecipientRegistry: Challenge period is not over'
+    );
+    if (request.recipientAddress == address(0)) {
+      // No recipient address: this is a removal request
+      _removeRecipient(_recipientId);
+      emit RecipientRemoved(_recipientId);
+    } else {
+      // WARNING: Could revert if no slots are available or if recipient limit is not set
+      uint256 recipientIndex = _addRecipient(_recipientId, request.recipientAddress);
+      emit RecipientAdded(
+        _recipientId,
+        request.recipientAddress,
+        request.recipientMetadata,
+        recipientIndex
+      );
+    }
+    bool isSent = request.requester.send(baseDeposit);
+    delete requests[_recipientId];
+    return isSent;
+  }
+}

--- a/contracts/tests/recipientRegistry.ts
+++ b/contracts/tests/recipientRegistry.ts
@@ -520,11 +520,11 @@ describe('Optimistic recipient registry', () => {
         recipientAddress, metadata, { value: baseDeposit },
       )
       const ownerBalanceBefore = await provider.getBalance(deployer.address)
-      const requestChallenged = registry.challengeRequest(recipientId)
-      await expect(requestChallenged)
+      const requestChallenged = await registry.challengeRequest(recipientId)
+      expect(requestChallenged)
         .to.emit(registry, 'RequestRejected')
         .withArgs(recipientId)
-      const txFee = await getTxFee(await requestChallenged)
+      const txFee = await getTxFee(requestChallenged)
       const ownerBalanceAfter = await provider.getBalance(deployer.address)
       expect(ownerBalanceBefore.sub(txFee).add(baseDeposit))
         .to.equal(ownerBalanceAfter)
@@ -552,9 +552,16 @@ describe('Optimistic recipient registry', () => {
         recipientAddress, metadata, { value: baseDeposit },
       )
       await provider.send('evm_increaseTime', [86400])
-      await expect(registry.connect(requester).executeRequest(recipientId))
+
+      const requesterBalanceBefore = await provider.getBalance(requester.address)
+      const requestExecuted = await registry.connect(requester).executeRequest(recipientId)
+      expect(requestExecuted)
         .to.emit(registry, 'RecipientAdded')
         .withArgs(recipientId, recipientAddress, metadata, recipientIndex)
+      const txFee = await getTxFee(requestExecuted)
+      const requesterBalanceAfter = await provider.getBalance(requester.address)
+      expect(requesterBalanceBefore.sub(txFee).add(baseDeposit))
+        .to.equal(requesterBalanceAfter)
 
       const currentBlock = await getCurrentBlockNumber()
       expect(await registry.getRecipientAddress(
@@ -670,11 +677,11 @@ describe('Optimistic recipient registry', () => {
 
       await registry.removeRecipient(recipientId, { value: baseDeposit })
       const ownerBalanceBefore = await provider.getBalance(deployer.address)
-      const requestChallenged = registry.challengeRequest(recipientId)
-      await expect(requestChallenged)
+      const requestChallenged = await registry.challengeRequest(recipientId)
+      expect(requestChallenged)
         .to.emit(registry, 'RequestRejected')
         .withArgs(recipientId)
-      const txFee = await getTxFee(await requestChallenged)
+      const txFee = await getTxFee(requestChallenged)
       const ownerBalanceAfter = await provider.getBalance(deployer.address)
       expect(ownerBalanceBefore.sub(txFee).add(baseDeposit))
         .to.equal(ownerBalanceAfter)
@@ -695,9 +702,16 @@ describe('Optimistic recipient registry', () => {
 
       await registry.connect(requester).removeRecipient(recipientId, { value: baseDeposit })
       await provider.send('evm_increaseTime', [86400])
-      await expect(registry.connect(requester).executeRequest(recipientId))
+
+      const requesterBalanceBefore = await provider.getBalance(requester.address)
+      const requestExecuted = await registry.connect(requester).executeRequest(recipientId)
+      expect(requestExecuted)
         .to.emit(registry, 'RecipientRemoved')
         .withArgs(recipientId)
+      const txFee = await getTxFee(requestExecuted)
+      const requesterBalanceAfter = await provider.getBalance(requester.address)
+      expect(requesterBalanceBefore.sub(txFee).add(baseDeposit))
+        .to.equal(requesterBalanceAfter)
 
       const currentBlock = await getCurrentBlockNumber()
       expect(await registry.getRecipientAddress(

--- a/contracts/utils/contracts.ts
+++ b/contracts/utils/contracts.ts
@@ -6,6 +6,11 @@ export async function getGasUsage(transaction: TransactionResponse): Promise<num
   return receipt.gasUsed.toNumber()
 }
 
+export async function getTxFee(transaction: TransactionResponse): Promise<BigNumber> {
+  const receipt = await transaction.wait()
+  return receipt.gasUsed.mul(transaction.gasPrice)
+}
+
 export async function getEventArg(
   transaction: TransactionResponse,
   contract: Contract,

--- a/vue-app/.env.example
+++ b/vue-app/.env.example
@@ -7,7 +7,7 @@ VUE_APP_CLRFUND_FACTORY_ADDRESS=0x5FC8d32690cc91D4c39d9d3abcBD16989F875707
 # Supported values: simple, brightid
 VUE_APP_USER_REGISTRY_TYPE=simple
 
-# Supported values: simple, kleros
+# Supported values: simple, optimistic, kleros
 VUE_APP_RECIPIENT_REGISTRY_TYPE=simple
 
 VUE_APP_EXTRA_ROUNDS=

--- a/vue-app/src/api/core.ts
+++ b/vue-app/src/api/core.ts
@@ -19,7 +19,7 @@ if (!['simple', 'brightid'].includes(userRegistryType as string)) {
   throw new Error('invalid user registry type')
 }
 export const recipientRegistryType = process.env.VUE_APP_RECIPIENT_REGISTRY_TYPE
-if (!['simple', 'kleros'].includes(recipientRegistryType as string)) {
+if (!['simple', 'optimistic', 'kleros'].includes(recipientRegistryType as string)) {
   throw new Error('invalid recipient registry type')
 }
 

--- a/vue-app/src/api/projects.ts
+++ b/vue-app/src/api/projects.ts
@@ -24,7 +24,7 @@ export async function getProjects(
   endBlock?: number,
 ): Promise<Project[]> {
   const registryAddress = await getRecipientRegistryAddress()
-  if (recipientRegistryType === 'simple') {
+  if (recipientRegistryType === 'simple' || recipientRegistryType === 'optimistic') {
     return await SimpleRegistry.getProjects(registryAddress, startBlock, endBlock)
   } else if (recipientRegistryType === 'kleros') {
     return await KlerosRegistry.getProjects(registryAddress, startBlock, endBlock)
@@ -35,7 +35,7 @@ export async function getProjects(
 
 export async function getProject(id: string): Promise<Project | null> {
   const registryAddress = await getRecipientRegistryAddress()
-  if (recipientRegistryType === 'simple') {
+  if (recipientRegistryType === 'simple' || recipientRegistryType === 'optimistic') {
     return await SimpleRegistry.getProject(registryAddress, id)
   } else if (recipientRegistryType === 'kleros') {
     return await KlerosRegistry.getProject(registryAddress, id)


### PR DESCRIPTION
`OptimisticRecipientRegistry` is a recipient registry with optimistic execution of registrations and removals. Anyone can submit registration request (`addRecipient()`) or removal request (`removeRecipient()`) along with a deposit (in base currency, like ETH or XDAI).

There's a challenge period during which the contract owner (arbitrator) can reject request (`challengeRequest()`). If request is rejected, the arbitrator takes the deposit.

Once the challenge period is over, anyone can execute the request (`executeRequest()`). This action adds or removes the recipient and the deposit is sent back to requester.