### PR TITLE
Move mnemonics to .env file and differentiate RPC URLs.

### DIFF
--- a/contracts/.env.example
+++ b/contracts/.env.example
@@ -1,3 +1,4 @@
 RINKEBY_JSONRPC_HTTP_URL=https://eth-rinkeby.alchemyapi.io/v2/ADD_API_KEY
 XDAI_JSONRPC_HTTP_URL=https://rpc.xdaichain.com
-MNEMONIC=
+WALLET_MNEMONIC=
+WALLET_PRIVATE_KEY=

--- a/contracts/.env.example
+++ b/contracts/.env.example
@@ -1,1 +1,3 @@
-ETHEREUM_JSONRPC_HTTP_URL=https://eth-rinkeby.alchemyapi.io/v2/ADD_API_KEY
+RINKEBY_JSONRPC_HTTP_URL=https://eth-rinkeby.alchemyapi.io/v2/ADD_API_KEY
+XDAI_JSONRPC_HTTP_URL=https://rpc.xdaichain.com
+MNEMONIC=

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -9,7 +9,7 @@ import '@nomiclabs/hardhat-ganache'
 dotenv.config()
 
 const GAS_LIMIT = 10000000
-const MNEMONIC = process.env.MNEMONIC || '';
+const WALLET_MNEMONIC = process.env.WALLET_MNEMONIC || '';
 
 const config: HardhatUserConfig = {
   networks: {
@@ -27,12 +27,12 @@ const config: HardhatUserConfig = {
     } as any,
     rinkeby: {
       url: process.env.RINKEBY_JSONRPC_HTTP_URL || 'http://127.0.0.1:8545',
-      accounts: { mnemonic: MNEMONIC },
+      accounts: { mnemonic: WALLET_MNEMONIC },
     },
     xdai: {
       url: process.env.XDAI_JSONRPC_HTTP_URL || 'https://rpc.xdaichain.com',
       timeout: 60000,
-      accounts: { mnemonic: MNEMONIC },
+      accounts: { mnemonic: WALLET_MNEMONIC },
     },
   },
   paths: {

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -9,6 +9,7 @@ import '@nomiclabs/hardhat-ganache'
 dotenv.config()
 
 const GAS_LIMIT = 10000000
+const MNEMONIC = process.env.MNEMONIC || '';
 
 const config: HardhatUserConfig = {
   networks: {
@@ -25,13 +26,13 @@ const config: HardhatUserConfig = {
       gasLimit: GAS_LIMIT,
     } as any,
     rinkeby: {
-      url: process.env.ETHEREUM_JSONRPC_HTTP_URL || 'http://127.0.0.1:8545',
-      accounts: { mnemonic: '' },
+      url: process.env.RINKEBY_JSONRPC_HTTP_URL || 'http://127.0.0.1:8545',
+      accounts: { mnemonic: MNEMONIC },
     },
     xdai: {
-      url: process.env.ETHEREUM_JSONRPC_HTTP_URL || 'https://rpc.xdaichain.com',
+      url: process.env.XDAI_JSONRPC_HTTP_URL || 'https://rpc.xdaichain.com',
       timeout: 60000,
-      accounts: { mnemonic: '' },
+      accounts: { mnemonic: MNEMONIC },
     },
   },
   paths: {


### PR DESCRIPTION
Quick PR to move mnemonic out of hardhat.config.ts and into the .env file, so there is less chance of someone accidentally pushing their mnemonic to github.