### PR TITLE
Upgrade to MACI 0.9.4 and x32 Circuits 

### DIFF
--- a/contracts/contracts/snarkVerifiers/BatchUpdateStateTreeVerifier32.sol
+++ b/contracts/contracts/snarkVerifiers/BatchUpdateStateTreeVerifier32.sol
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: MIT
+
+// Copyright 2017 Christian Reitwiessner
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+// 2019 OKIMS
+
+pragma solidity ^0.6.12;
+
+library Pairing {
+
+    uint256 constant PRIME_Q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+
+    struct G1Point {
+        uint256 X;
+        uint256 Y;
+    }
+
+    // Encoding of field elements is: X[0] * z + X[1]
+    struct G2Point {
+        uint256[2] X;
+        uint256[2] Y;
+    }
+
+    /*
+     * @return The negation of p, i.e. p.plus(p.negate()) should be zero. 
+     */
+    function negate(G1Point memory p) internal pure returns (G1Point memory) {
+
+        // The prime q in the base field F_q for G1
+        if (p.X == 0 && p.Y == 0) {
+            return G1Point(0, 0);
+        } else {
+            return G1Point(p.X, PRIME_Q - (p.Y % PRIME_Q));
+        }
+    }
+
+    /*
+     * @return The sum of two points of G1
+     */
+    function plus(
+        G1Point memory p1,
+        G1Point memory p2
+    ) internal view returns (G1Point memory r) {
+
+        uint256[4] memory input;
+        input[0] = p1.X;
+        input[1] = p1.Y;
+        input[2] = p2.X;
+        input[3] = p2.Y;
+        bool success;
+
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
+            // Use "invalid" to make gas estimation work
+            switch success case 0 { invalid() }
+        }
+
+        require(success,"pairing-add-failed");
+    }
+
+    /*
+     * @return The product of a point on G1 and a scalar, i.e.
+     *         p == p.scalar_mul(1) and p.plus(p) == p.scalar_mul(2) for all
+     *         points p.
+     */
+    function scalar_mul(G1Point memory p, uint256 s) internal view returns (G1Point memory r) {
+
+        uint256[3] memory input;
+        input[0] = p.X;
+        input[1] = p.Y;
+        input[2] = s;
+        bool success;
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
+            // Use "invalid" to make gas estimation work
+            switch success case 0 { invalid() }
+        }
+        require (success,"pairing-mul-failed");
+    }
+
+    /* @return The result of computing the pairing check
+     *         e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1
+     *         For example,
+     *         pairing([P1(), P1().negate()], [P2(), P2()]) should return true.
+     */
+    function pairing(
+        G1Point memory a1,
+        G2Point memory a2,
+        G1Point memory b1,
+        G2Point memory b2,
+        G1Point memory c1,
+        G2Point memory c2,
+        G1Point memory d1,
+        G2Point memory d2
+    ) internal view returns (bool) {
+
+        G1Point[4] memory p1 = [a1, b1, c1, d1];
+        G2Point[4] memory p2 = [a2, b2, c2, d2];
+
+        uint256 inputSize = 24;
+        uint256[] memory input = new uint256[](inputSize);
+
+        for (uint256 i = 0; i < 4; i++) {
+            uint256 j = i * 6;
+            input[j + 0] = p1[i].X;
+            input[j + 1] = p1[i].Y;
+            input[j + 2] = p2[i].X[0];
+            input[j + 3] = p2[i].X[1];
+            input[j + 4] = p2[i].Y[0];
+            input[j + 5] = p2[i].Y[1];
+        }
+
+        uint256[1] memory out;
+        bool success;
+
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
+            // Use "invalid" to make gas estimation work
+            switch success case 0 { invalid() }
+        }
+
+        require(success,"pairing-opcode-failed");
+
+        return out[0] != 0;
+    }
+}
+
+contract BatchUpdateStateTreeVerifier32 {
+
+    using Pairing for *;
+
+    uint256 constant SNARK_SCALAR_FIELD = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
+    uint256 constant PRIME_Q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+
+    struct VerifyingKey {
+        Pairing.G1Point alpha1;
+        Pairing.G2Point beta2;
+        Pairing.G2Point gamma2;
+        Pairing.G2Point delta2;
+        Pairing.G1Point[25] IC;
+    }
+
+    struct Proof {
+        Pairing.G1Point A;
+        Pairing.G2Point B;
+        Pairing.G1Point C;
+    }
+
+    function verifyingKey() internal pure returns (VerifyingKey memory vk) {
+        vk.alpha1 = Pairing.G1Point(uint256(2235937757258328332581655207316854914340553041478756749021922386043254497665),uint256(11720695076632845600035435519386961195137050119051159881119328470568375901061));
+        vk.beta2 = Pairing.G2Point([uint256(18103312586997372723464065125468726628197103937398148351874079500906002078514),uint256(3521241463040229090496972414283999306378042701894409495991649947043913050390)], [uint256(19929222577579677319710308208655935830382430571925744018028233535451768572526),uint256(2713488580683808567223254461296987686393416756219077378633699157752784449871)]);
+        vk.gamma2 = Pairing.G2Point([uint256(18540033106735871504246221953284252727449583113344978088798752551559197497443),uint256(11804507394712288367663827325809152799963322749311995594214433375808748914215)], [uint256(7823444017721090114052934461767123920657200397414318893992672133734334584881),uint256(381539947305595214533183072009982233806337443107151710535066901935181836650)]);
+        vk.delta2 = Pairing.G2Point([uint256(13777830633300304139191093890421583212822007120835768179730867378433207369904),uint256(5829308442558755354882021024059658392511579302722950339672751965830178369479)], [uint256(3247971301408566159364701679393539201504071675477219748559808130461833317206),uint256(20333401927295807868473825746451131502855146064139046665350946639946989255290)]);
+        vk.IC[0] = Pairing.G1Point(uint256(12695296843741290243689381493557344935288860265047293012366283732179354585998),uint256(8756234222257929396036211927997035681483199097361823776457523938231702657637));
+        vk.IC[1] = Pairing.G1Point(uint256(19427060885837198291358374320196723084935525206551352881413292228008641375494),uint256(17830025099056800507919694199083128206588010134164569106894828438761905032458));
+        vk.IC[2] = Pairing.G1Point(uint256(410478146407936532689270128315003070671881564424239715170777648878967168005),uint256(19810008246942770361558893286482792592821114623562524395734095279442205700805));
+        vk.IC[3] = Pairing.G1Point(uint256(16927932954172000562734191935150272341340300065159146447389567055435697197896),uint256(7080985430376548388712273850247201104283444559574087251008037877021942324388));
+        vk.IC[4] = Pairing.G1Point(uint256(16230357772827331182078389034367129255766008017458394951654453835970997773946),uint256(14390597016939564779231872532412964300980781945004466358993998728674970309401));
+        vk.IC[5] = Pairing.G1Point(uint256(13714106385150866732996352043897273245837658980446605229373226331378168393032),uint256(486150390705720151962722842770974288776559483789878327517085343215375560197));
+        vk.IC[6] = Pairing.G1Point(uint256(17768923331894319515675582767948565732688231025317939555708699614152398211686),uint256(8499610897814284712396152304339583329559266108913886418999627219565622002315));
+        vk.IC[7] = Pairing.G1Point(uint256(14415647971716124875365599377021987010020281756838687529386783498764570820512),uint256(14613451060692886380252911494947779806626467670508276424823896732115700932878));
+        vk.IC[8] = Pairing.G1Point(uint256(16764983637282451325253712526116676245825038387105887732952918407603662725617),uint256(1352524463256846201723591130214587605935782520895303289524343032854923110908));
+        vk.IC[9] = Pairing.G1Point(uint256(10056087566202527332631589268663832673613483884145297923102443097932637361605),uint256(16730779773798332173061611611644870364986949778018646363117835815193258915616));
+        vk.IC[10] = Pairing.G1Point(uint256(13290900503321714658935311585568872029990198888697506684512806338887123938831),uint256(8114386552118049168577883416679077864672808493670718294274215610717572843963));
+        vk.IC[11] = Pairing.G1Point(uint256(7782896038733621968832942200150060348729169883217332185424996914395075738032),uint256(20682377337106534901146812854074383535826740744181459358117072396602346484606));
+        vk.IC[12] = Pairing.G1Point(uint256(617901749705332346513537208464626960953097676177271170612675508795831094045),uint256(16186736174707113904460258035003488129644568973675010912669231698078479023222));
+        vk.IC[13] = Pairing.G1Point(uint256(14477430187013369520618676362674934644081527218666492121095639975702523047093),uint256(13914336563460888476578316933419114155531706131840740221252768233483396324368));
+        vk.IC[14] = Pairing.G1Point(uint256(5924187723811910208644055167942297972031087776772786313548743929893285133800),uint256(16361662290370920310451572623845118040008422660307051722847580146457871736989));
+        vk.IC[15] = Pairing.G1Point(uint256(17090166758717550052215882897464335068092945362735421722892605678597646540057),uint256(16398300913997240579023943771253062149083261407674822502769328439978123578689));
+        vk.IC[16] = Pairing.G1Point(uint256(7574674900722229272749996430153170469828315370484171764654649633984135615279),uint256(5069496413177806803124281195026969110815809700378025228167702995573586665836));
+        vk.IC[17] = Pairing.G1Point(uint256(10441721171682792688941253005732564080622492912137608063443699246450315451923),uint256(15398991661933253947425996624904544110556542286879829919064231912826539570526));
+        vk.IC[18] = Pairing.G1Point(uint256(17674413698382420009917026819492643888193304168981044450949863673048991538414),uint256(9527495908817414334530454481572961657315487660716656106473790248118706961070));
+        vk.IC[19] = Pairing.G1Point(uint256(1305107076420532159069082995140140252760452422131801890994478405555848637105),uint256(20641138567711443797973886773618825716028720528130685248162815978012474008318));
+        vk.IC[20] = Pairing.G1Point(uint256(20823282309713566159682969445806802229330524100205102112933548669175660181229),uint256(1585818072534898485010386083641472744958777764688589865815398129584392257276));
+        vk.IC[21] = Pairing.G1Point(uint256(8602838104248160338689652217659749853668007141927006509298162439781733248626),uint256(3031659185416842164642200249451988498992828231012099148797461669175568452385));
+        vk.IC[22] = Pairing.G1Point(uint256(15062697778545981716015498304594399446175287977109202577788056450289044074530),uint256(14595426536584631660528478734922855298873285152019524939752258039412967085035));
+        vk.IC[23] = Pairing.G1Point(uint256(9203110864527021095159434212260506563713459019946440113668834753150698387275),uint256(6633831390080912793725673980685906970380191858784131579135247042888943087524));
+        vk.IC[24] = Pairing.G1Point(uint256(9703769305917897594120374760147891009572024854624222123846683638776025013089),uint256(16754141899540658922386431411326524911697563540800148668488844811424060636134));
+
+    }
+    
+    /*
+     * @returns Whether the proof is valid given the hardcoded verifying key
+     *          above and the public inputs
+     */
+    function verifyProof(
+        uint256[2] memory a,
+        uint256[2][2] memory b,
+        uint256[2] memory c,
+        uint256[] memory input
+    ) public view returns (bool) {
+
+        Proof memory proof;
+        proof.A = Pairing.G1Point(a[0], a[1]);
+        proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
+        proof.C = Pairing.G1Point(c[0], c[1]);
+
+        VerifyingKey memory vk = verifyingKey();
+
+        // Compute the linear combination vk_x
+        Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
+
+        // Make sure that proof.A, B, and C are each less than the prime q
+        require(proof.A.X < PRIME_Q, "verifier-aX-gte-prime-q");
+        require(proof.A.Y < PRIME_Q, "verifier-aY-gte-prime-q");
+
+        require(proof.B.X[0] < PRIME_Q, "verifier-bX0-gte-prime-q");
+        require(proof.B.Y[0] < PRIME_Q, "verifier-bY0-gte-prime-q");
+
+        require(proof.B.X[1] < PRIME_Q, "verifier-bX1-gte-prime-q");
+        require(proof.B.Y[1] < PRIME_Q, "verifier-bY1-gte-prime-q");
+
+        require(proof.C.X < PRIME_Q, "verifier-cX-gte-prime-q");
+        require(proof.C.Y < PRIME_Q, "verifier-cY-gte-prime-q");
+
+        // Make sure that every input is less than the snark scalar field
+        //for (uint256 i = 0; i < input.length; i++) {
+        for (uint256 i = 0; i < 24; i++) {
+            require(input[i] < SNARK_SCALAR_FIELD,"verifier-gte-snark-scalar-field");
+            vk_x = Pairing.plus(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
+        }
+
+        vk_x = Pairing.plus(vk_x, vk.IC[0]);
+
+        return Pairing.pairing(
+            Pairing.negate(proof.A),
+            proof.B,
+            vk.alpha1,
+            vk.beta2,
+            vk_x,
+            vk.gamma2,
+            proof.C,
+            vk.delta2
+        );
+    }
+}

--- a/contracts/contracts/snarkVerifiers/QuadVoteTallyVerifier32.sol
+++ b/contracts/contracts/snarkVerifiers/QuadVoteTallyVerifier32.sol
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: MIT
+
+// Copyright 2017 Christian Reitwiessner
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+// 2019 OKIMS
+
+pragma solidity ^0.6.12;
+
+library Pairing {
+
+    uint256 constant PRIME_Q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+
+    struct G1Point {
+        uint256 X;
+        uint256 Y;
+    }
+
+    // Encoding of field elements is: X[0] * z + X[1]
+    struct G2Point {
+        uint256[2] X;
+        uint256[2] Y;
+    }
+
+    /*
+     * @return The negation of p, i.e. p.plus(p.negate()) should be zero. 
+     */
+    function negate(G1Point memory p) internal pure returns (G1Point memory) {
+
+        // The prime q in the base field F_q for G1
+        if (p.X == 0 && p.Y == 0) {
+            return G1Point(0, 0);
+        } else {
+            return G1Point(p.X, PRIME_Q - (p.Y % PRIME_Q));
+        }
+    }
+
+    /*
+     * @return The sum of two points of G1
+     */
+    function plus(
+        G1Point memory p1,
+        G1Point memory p2
+    ) internal view returns (G1Point memory r) {
+
+        uint256[4] memory input;
+        input[0] = p1.X;
+        input[1] = p1.Y;
+        input[2] = p2.X;
+        input[3] = p2.Y;
+        bool success;
+
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
+            // Use "invalid" to make gas estimation work
+            switch success case 0 { invalid() }
+        }
+
+        require(success,"pairing-add-failed");
+    }
+
+    /*
+     * @return The product of a point on G1 and a scalar, i.e.
+     *         p == p.scalar_mul(1) and p.plus(p) == p.scalar_mul(2) for all
+     *         points p.
+     */
+    function scalar_mul(G1Point memory p, uint256 s) internal view returns (G1Point memory r) {
+
+        uint256[3] memory input;
+        input[0] = p.X;
+        input[1] = p.Y;
+        input[2] = s;
+        bool success;
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
+            // Use "invalid" to make gas estimation work
+            switch success case 0 { invalid() }
+        }
+        require (success,"pairing-mul-failed");
+    }
+
+    /* @return The result of computing the pairing check
+     *         e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1
+     *         For example,
+     *         pairing([P1(), P1().negate()], [P2(), P2()]) should return true.
+     */
+    function pairing(
+        G1Point memory a1,
+        G2Point memory a2,
+        G1Point memory b1,
+        G2Point memory b2,
+        G1Point memory c1,
+        G2Point memory c2,
+        G1Point memory d1,
+        G2Point memory d2
+    ) internal view returns (bool) {
+
+        G1Point[4] memory p1 = [a1, b1, c1, d1];
+        G2Point[4] memory p2 = [a2, b2, c2, d2];
+
+        uint256 inputSize = 24;
+        uint256[] memory input = new uint256[](inputSize);
+
+        for (uint256 i = 0; i < 4; i++) {
+            uint256 j = i * 6;
+            input[j + 0] = p1[i].X;
+            input[j + 1] = p1[i].Y;
+            input[j + 2] = p2[i].X[0];
+            input[j + 3] = p2[i].X[1];
+            input[j + 4] = p2[i].Y[0];
+            input[j + 5] = p2[i].Y[1];
+        }
+
+        uint256[1] memory out;
+        bool success;
+
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
+            // Use "invalid" to make gas estimation work
+            switch success case 0 { invalid() }
+        }
+
+        require(success,"pairing-opcode-failed");
+
+        return out[0] != 0;
+    }
+}
+
+contract QuadVoteTallyVerifier32 {
+
+    using Pairing for *;
+
+    uint256 constant SNARK_SCALAR_FIELD = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
+    uint256 constant PRIME_Q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+
+    struct VerifyingKey {
+        Pairing.G1Point alpha1;
+        Pairing.G2Point beta2;
+        Pairing.G2Point gamma2;
+        Pairing.G2Point delta2;
+        Pairing.G1Point[11] IC;
+    }
+
+    struct Proof {
+        Pairing.G1Point A;
+        Pairing.G2Point B;
+        Pairing.G1Point C;
+    }
+
+    function verifyingKey() internal pure returns (VerifyingKey memory vk) {
+        vk.alpha1 = Pairing.G1Point(uint256(9788127595119201866856617003695348381494833524466400639949073585957021339037),uint256(17932521094406734810716540317777009267479808128307339657586752246845966324546));
+        vk.beta2 = Pairing.G2Point([uint256(21696649512957474520766095764799013940939016236949108680242351137594278285669),uint256(9016446391367028110234589585753924330264825516230321143634114592563371307117)], [uint256(7087399056167398372761076892757707007018670953459473525927429087917826945053),uint256(9659617587389110165682052807238376129317889332523805252341223621597875480794)]);
+        vk.gamma2 = Pairing.G2Point([uint256(13962369966765040668829655136924014476219060175797181969275750747389840617448),uint256(19823961448325229305204277789628974240377979114016419863625529107132599746377)], [uint256(21003505158985748144125490558991246355533878946496416497168816402925446815665),uint256(14051298214898763705311654324232715279911394037278143384416856363195856079315)]);
+        vk.delta2 = Pairing.G2Point([uint256(11530440852220161646149031563657779726613020784068593716469602804710970865016),uint256(14257554911323500151026989745783771294105663833290894907603970279224038797748)], [uint256(5383887732348773780113795775564370073998899934497202895231896126994803955425),uint256(11233493274723621382210142971760402149935803222743635486876071121294805940438)]);
+        vk.IC[0] = Pairing.G1Point(uint256(10331630364560579918439924807409069040574467453347970997831619467700630786260),uint256(7352703907083746684727908159265924004558758803834300636605141089397401744276));
+        vk.IC[1] = Pairing.G1Point(uint256(2383454224874693764660765415618474893054453576782110395746877001592325997813),uint256(1542959527417798518589026170675817148209513312208940161838188351540305261351));
+        vk.IC[2] = Pairing.G1Point(uint256(18884898847905030735430424271903368807631300921120481538677323215944429955882),uint256(7994371495659448868909256534360335828331664970438054963950762473745447828579));
+        vk.IC[3] = Pairing.G1Point(uint256(12191131903986550861667269414449440505467282925229091327826064446444042925410),uint256(10287091939791432810651612894102236781556081667714076895904551125587377961104));
+        vk.IC[4] = Pairing.G1Point(uint256(20501120058293061653434025117099905624068740273769213189741054505135138713238),uint256(17165567928850585462269967533098885781515290109705663694639983179304840313303));
+        vk.IC[5] = Pairing.G1Point(uint256(20751307669795641184935675550765974725507672821656889501312345885830120955045),uint256(11018164791073843718441881117561339638946066654006646219940842025563325157728));
+        vk.IC[6] = Pairing.G1Point(uint256(18159318129566988733741597410767431681008828827772613186940913319367318549079),uint256(12396436918085027159836905968189917573204122166878503885239851905631641956072));
+        vk.IC[7] = Pairing.G1Point(uint256(13060171889041434447360216444511148806054464772702115083624471143224891275324),uint256(10094424363784529626834006689496204497794067280043536139893786658250635934309));
+        vk.IC[8] = Pairing.G1Point(uint256(6854173124674957005941305536675433520123924432035620687587028033143445025531),uint256(19506224151286244452202284185755930627153417086070884411467083228467399266356));
+        vk.IC[9] = Pairing.G1Point(uint256(18168338073015895229874309533757429566747399006686550780596425981177180963553),uint256(21672263069691916535914406330276563680996218330501255716766232162984703727459));
+        vk.IC[10] = Pairing.G1Point(uint256(12867344578516149856332575271023915354048241534592007123391907132955424635582),uint256(1166388922196880405559962045533802218202004023209252233378224410860556005741));
+
+    }
+    
+    /*
+     * @returns Whether the proof is valid given the hardcoded verifying key
+     *          above and the public inputs
+     */
+    function verifyProof(
+        uint256[2] memory a,
+        uint256[2][2] memory b,
+        uint256[2] memory c,
+        uint256[] memory input
+    ) public view returns (bool) {
+
+        Proof memory proof;
+        proof.A = Pairing.G1Point(a[0], a[1]);
+        proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
+        proof.C = Pairing.G1Point(c[0], c[1]);
+
+        VerifyingKey memory vk = verifyingKey();
+
+        // Compute the linear combination vk_x
+        Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
+
+        // Make sure that proof.A, B, and C are each less than the prime q
+        require(proof.A.X < PRIME_Q, "verifier-aX-gte-prime-q");
+        require(proof.A.Y < PRIME_Q, "verifier-aY-gte-prime-q");
+
+        require(proof.B.X[0] < PRIME_Q, "verifier-bX0-gte-prime-q");
+        require(proof.B.Y[0] < PRIME_Q, "verifier-bY0-gte-prime-q");
+
+        require(proof.B.X[1] < PRIME_Q, "verifier-bX1-gte-prime-q");
+        require(proof.B.Y[1] < PRIME_Q, "verifier-bY1-gte-prime-q");
+
+        require(proof.C.X < PRIME_Q, "verifier-cX-gte-prime-q");
+        require(proof.C.Y < PRIME_Q, "verifier-cY-gte-prime-q");
+
+        // Make sure that every input is less than the snark scalar field
+        //for (uint256 i = 0; i < input.length; i++) {
+        for (uint256 i = 0; i < 10; i++) {
+            require(input[i] < SNARK_SCALAR_FIELD,"verifier-gte-snark-scalar-field");
+            vk_x = Pairing.plus(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
+        }
+
+        vk_x = Pairing.plus(vk_x, vk.IC[0]);
+
+        return Pairing.pairing(
+            Pairing.negate(proof.A),
+            proof.B,
+            vk.alpha1,
+            vk.beta2,
+            vk_x,
+            vk.gamma2,
+            proof.C,
+            vk.delta2
+        );
+    }
+}

--- a/contracts/contracts/snarkVerifiers/README.md
+++ b/contracts/contracts/snarkVerifiers/README.md
@@ -4,3 +4,4 @@ Trusted setup:
 
 - 'test' circuits: https://gateway.pinata.cloud/ipfs/Qmbi3nqjBwANPMk5BRyKjCJ4QSHK6WNp7v9NLLo4uwrG1f
 - 'medium' circuits: https://gateway.pinata.cloud/ipfs/QmRzp3vkFPNHPpXiu7iKpPqVnZB97wq7gyih2mp6pa5bmD
+- 'x32' circuits: https://gateway.pinata.cloud/ipfs/QmWSxPBNYDtsK23KwYdMtcDaJg3gWS3LBsqMnENrVG6nmc

--- a/contracts/e2e/index.ts
+++ b/contracts/e2e/index.ts
@@ -59,9 +59,9 @@ describe('End-to-end Tests', function () {
     // Deploy funding round factory
     const poseidonT3 = await deployContract(deployer, ':PoseidonT3')
     const poseidonT6 = await deployContract(deployer, ':PoseidonT6')
-    const batchUstVerifier = await deployContract(deployer, 'BatchUpdateStateTreeVerifier')
-    const qvtVerifier = await deployContract(deployer, 'QuadVoteTallyVerifier')
-    const maciFactory = await deployMaciFactory(deployer, 'test', {
+    const batchUstVerifier = await deployContract(deployer, 'BatchUpdateStateTreeVerifier32')
+    const qvtVerifier = await deployContract(deployer, 'QuadVoteTallyVerifier32')
+    const maciFactory = await deployMaciFactory(deployer, 'x32', {
       poseidonT3,
       poseidonT6,
       batchUstVerifier,

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -5,10 +5,13 @@ import dotenv from 'dotenv'
 import { HardhatUserConfig, task } from 'hardhat/config'
 import '@nomiclabs/hardhat-waffle'
 import '@nomiclabs/hardhat-ganache'
+import 'hardhat-contract-sizer';
+
 
 dotenv.config()
 
-const GAS_LIMIT = 10000000
+
+const GAS_LIMIT = 20000000
 const WALLET_MNEMONIC = process.env.WALLET_MNEMONIC || '';
 
 const config: HardhatUserConfig = {
@@ -39,15 +42,68 @@ const config: HardhatUserConfig = {
     artifacts: 'build/contracts',
     tests: 'tests',
   },
+  contractSizer: {
+    alphaSort: true,
+    runOnCompile: true,
+    disambiguatePaths: false,
+  },
   solidity: {
     version: '0.6.12',
     settings: {
       optimizer: {
         enabled: true,
-        runs: 20,
+        runs: 0,
       },
     },
+    overrides: {
+      "contracts/snarkVerifiers/BatchUpdateStateTreeVerifier32.sol": {
+        version: "0.6.12",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 10000000,
+          },
+        },
+      },
+      "contracts/snarkVerifiers/QuadVoteTallyVerifier32.sol": {
+        version: "0.6.12",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 10000000,
+          },
+        },
+      },
+      "contracts/recipientRegistry/OptimisticRecipientRegistry.sol": {
+        version: "0.6.12",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 1000000,
+          },
+        },
+      },
+      "contracts/userRegistry/SimpleUserRegistry.sol": {
+        version: "0.6.12",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 1000000,
+          },
+        },
+      },
+      "contracts/userRegistry/BrightIdUserRegistry.sol": {
+        version: "0.6.12",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 1000000,
+          },
+        },
+      }
+    }
   },
+  
 };
 
 task('compile', 'Compiles the entire project, building all artifacts', async (_, { config }, runSuper) => {

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -11,7 +11,7 @@ import 'hardhat-contract-sizer';
 dotenv.config()
 
 
-const GAS_LIMIT = 20000000
+const GAS_LIMIT = 14000000
 const WALLET_MNEMONIC = process.env.WALLET_MNEMONIC || '';
 
 const config: HardhatUserConfig = {
@@ -52,10 +52,28 @@ const config: HardhatUserConfig = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 0,
+        runs: 200,
       },
     },
     overrides: {
+      "contracts/FundingRoundFactory.sol": {
+        version: "0.6.12",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 1000000,
+          },
+        },
+      },
+      "contracts/FundingRound.sol": {
+        version: "0.6.12",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 1000000,
+          },
+        },
+      },
       "contracts/snarkVerifiers/BatchUpdateStateTreeVerifier32.sol": {
         version: "0.6.12",
         settings: {

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -11,7 +11,7 @@ import 'hardhat-contract-sizer';
 dotenv.config()
 
 
-const GAS_LIMIT = 14000000
+const GAS_LIMIT = 20000000
 const WALLET_MNEMONIC = process.env.WALLET_MNEMONIC || '';
 
 const config: HardhatUserConfig = {
@@ -22,6 +22,9 @@ const config: HardhatUserConfig = {
     },
     localhost: {
       url: 'http://127.0.0.1:18545',
+      timeout: 60000,
+      gas: GAS_LIMIT,
+      blockGasLimit: GAS_LIMIT,
     },
     ganache: {
       // Workaround for https://github.com/nomiclabs/hardhat/issues/518

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@openzeppelin/contracts": "3.2.0",
     "dotenv": "^8.2.0",
-    "maci-contracts": "0.7.4",
+    "maci-contracts": "0.9.4",
     "solidity-rlp": "2.0.3"
   },
   "devDependencies": {
@@ -41,10 +41,11 @@
     "ethereum-waffle": "~3.2.2",
     "ethers": "^5.0.17",
     "hardhat": "^2.0.11",
+    "hardhat-contract-sizer": "^2.0.3",
     "ipfs-only-hash": "^2.0.1",
-    "maci-cli": "0.7.4",
-    "maci-crypto": "~0.7.4",
-    "maci-domainobjs": "~0.7.4",
+    "maci-cli": "0.9.4",
+    "maci-crypto": "~0.9.1",
+    "maci-domainobjs": "~0.9.1",
     "solhint": "^3.3.2",
     "ts-generator": "^0.0.8",
     "ts-node": "^8.8.1",

--- a/contracts/tests/factory.ts
+++ b/contracts/tests/factory.ts
@@ -189,7 +189,7 @@ describe('Funding Round Factory', () => {
       const deployed = factory.deployNewRound()
       await expect(deployed).to.emit(factory, 'RoundStarted')
       const deployTx = await deployed
-      expect(await getGasUsage(deployTx)).lessThan(9000000)
+      expect(await getGasUsage(deployTx)).lessThan(11500000)
 
       const fundingRoundAddress = await factory.getCurrentRound();
       expect(fundingRoundAddress).to.properAddress;

--- a/contracts/tests/maciFactory.ts
+++ b/contracts/tests/maciFactory.ts
@@ -34,18 +34,18 @@ describe('MACI factory', () => {
 
   it('sets default MACI parameters', async () => {
     const { maxUsers, maxMessages, maxVoteOptions } = await maciFactory.maxValues()
-    expect(maxUsers).to.equal(15)
-    expect(maxMessages).to.equal(15)
-    expect(maxVoteOptions).to.equal(24)
+    expect(maxUsers).to.equal(4294967295)
+    expect(maxMessages).to.equal(4294967295)
+    expect(maxVoteOptions).to.equal(124)
     expect(await maciFactory.signUpDuration()).to.equal(604800);
     expect(await maciFactory.votingDuration()).to.equal(604800);
   });
 
   it('sets MACI parameters', async () => {
     maciParameters.update({
-      stateTreeDepth: 8,
-      messageTreeDepth: 12,
-      voteOptionTreeDepth: 4,
+      stateTreeDepth: 32,
+      messageTreeDepth: 32,
+      voteOptionTreeDepth: 3,
       signUpDuration: 86400,
       votingDuration: 86400,
     });
@@ -82,7 +82,7 @@ describe('MACI factory', () => {
     await expect(maciDeployed).to.emit(maciFactory, 'MaciDeployed');
 
     const deployTx = await maciDeployed;
-    expect(await getGasUsage(deployTx)).lessThan(7200000);
+    expect(await getGasUsage(deployTx)).lessThan(9000000);
   });
 
   it('allows only owner to deploy MACI', async () => {

--- a/contracts/tests/round.ts
+++ b/contracts/tests/round.ts
@@ -290,7 +290,7 @@ describe('Funding Round', () => {
       );
       await expect(messagePublished).to.emit(maci, 'PublishMessage');
       const publishTx = await messagePublished;
-      expect(await getGasUsage(publishTx)).lessThan(800000);
+      expect(await getGasUsage(publishTx)).lessThan(2100000);
     });
 
     it('submits a key-changing message', async () => {
@@ -361,7 +361,7 @@ describe('Funding Round', () => {
         encPubKeys.push(encPubKey.asContractParam());
       }
       const messageBatchSubmitted = await fundingRound.submitMessageBatch(messages, encPubKeys);
-      expect(await getGasUsage(messageBatchSubmitted)).lessThan(2100000);
+      expect(await getGasUsage(messageBatchSubmitted)).lessThan(4900000);
     }).timeout(100000);
   });
 

--- a/contracts/utils/deployment.ts
+++ b/contracts/utils/deployment.ts
@@ -19,9 +19,9 @@ export function linkBytecode(
 
 const CIRCUITS: {[name: string]: any} = {
   test: {
-    batchUstVerifier: 'BatchUpdateStateTreeVerifier32',
-    qvtVerifier: 'QuadVoteTallyVerifier32',
-    treeDepths: { stateTreeDepth: 32, messageTreeDepth: 32, voteOptionTreeDepth: 3 },
+    batchUstVerifier: 'BatchUpdateStateTreeVerifier',
+    qvtVerifier: 'QuadVoteTallyVerifier',
+    treeDepths: { stateTreeDepth: 4, messageTreeDepth: 4, voteOptionTreeDepth: 2 },
   },
   small: {
     batchUstVerifier: 'BatchUpdateStateTreeVerifierSmall',
@@ -32,6 +32,11 @@ const CIRCUITS: {[name: string]: any} = {
     batchUstVerifier: 'BatchUpdateStateTreeVerifierMedium',
     qvtVerifier: 'QuadVoteTallyVerifierMedium',
     treeDepths: { stateTreeDepth: 9, messageTreeDepth: 13, voteOptionTreeDepth: 3 },
+  },
+  x32: {
+    batchUstVerifier: 'BatchUpdateStateTreeVerifier32',
+    qvtVerifier: 'QuadVoteTallyVerifier32',
+    treeDepths: { stateTreeDepth: 32, messageTreeDepth: 32, voteOptionTreeDepth: 3 },
   },
 }
 
@@ -54,7 +59,7 @@ interface MaciFactoryDependencies {
 
 export async function deployMaciFactory(
   account: Signer,
-  circuit = 'test',
+  circuit = 'x32',
   { poseidonT3, poseidonT6, batchUstVerifier, qvtVerifier }: MaciFactoryDependencies = {},
 ): Promise<Contract> {
   if (!poseidonT3) {

--- a/contracts/utils/deployment.ts
+++ b/contracts/utils/deployment.ts
@@ -19,9 +19,9 @@ export function linkBytecode(
 
 const CIRCUITS: {[name: string]: any} = {
   test: {
-    batchUstVerifier: 'BatchUpdateStateTreeVerifier',
-    qvtVerifier: 'QuadVoteTallyVerifier',
-    treeDepths: { stateTreeDepth: 4, messageTreeDepth: 4, voteOptionTreeDepth: 2 },
+    batchUstVerifier: 'BatchUpdateStateTreeVerifier32',
+    qvtVerifier: 'QuadVoteTallyVerifier32',
+    treeDepths: { stateTreeDepth: 32, messageTreeDepth: 32, voteOptionTreeDepth: 3 },
   },
   small: {
     batchUstVerifier: 'BatchUpdateStateTreeVerifierSmall',

--- a/contracts/utils/maci.ts
+++ b/contracts/utils/maci.ts
@@ -4,11 +4,11 @@ import { Keypair, PubKey, Command, Message } from 'maci-domainobjs'
 
 export class MaciParameters {
 
-  stateTreeDepth = 4
-  messageTreeDepth = 4
-  voteOptionTreeDepth = 2
-  tallyBatchSize = 4
-  messageBatchSize = 4
+  stateTreeDepth = 32
+  messageTreeDepth = 32
+  voteOptionTreeDepth = 3
+  tallyBatchSize = 8
+  messageBatchSize = 8
   batchUstVerifier!: string
   qvtVerifier!: string
   signUpDuration = 7 * 86400

--- a/docs/coordinator.md
+++ b/docs/coordinator.md
@@ -2,21 +2,29 @@
 
 ## Coordinate using MACI CLI
 
-Clone the [MACI repo](https://github.com/appliedzkp/maci/) and switch to version v0.7.1:
+Clone the [MACI repo](https://github.com/appliedzkp/maci/) and switch to version v0.9.4:
 
 ```
 git clone https://github.com/appliedzkp/maci.git
 cd maci/
-git checkout v0.7.1
+git checkout v0.9.4
 ```
 
 Follow instructions in README.md to install necessary dependencies.
 
+### Medium Circuits
 Download [zkSNARK parameters](https://gateway.pinata.cloud/ipfs/QmRzp3vkFPNHPpXiu7iKpPqVnZB97wq7gyih2mp6pa5bmD) for 'medium' circuits into `circuits/params/` directory and rebuild the keys:
 
 ```
 cd circuits
 ./scripts/buildSnarksMedium.sh
+```
+### x32 Circuits
+Download [zkSNARK parameters](https://gateway.pinata.cloud/ipfs/QmWSxPBNYDtsK23KwYdMtcDaJg3gWS3LBsqMnENrVG6nmc) for 'x32' circuits into `circuits/params/` directory and rebuild the keys:
+
+```
+cd circuits
+./scripts/buildSnarks32.sh
 ```
 
 Recompile the contracts:

--- a/docs/trusted-setup.md
+++ b/docs/trusted-setup.md
@@ -4,21 +4,31 @@
 
 ### Verify using MACI CLI
 
-Clone the [MACI repo](https://github.com/appliedzkp/maci/) and switch to version v0.7.1:
+Clone the [MACI repo](https://github.com/appliedzkp/maci/) and switch to version v0.9.4:
 
 ```
 git clone https://github.com/appliedzkp/maci.git
 cd maci/
-git checkout v0.7.1
+git checkout v0.9.4
 ```
 
 Follow instructions in README.md to install necessary dependencies.
 
+
+### Medium Circuits
 Download [zkSNARK parameters](https://gateway.pinata.cloud/ipfs/QmRzp3vkFPNHPpXiu7iKpPqVnZB97wq7gyih2mp6pa5bmD) for 'medium' circuits into `circuits/params/` directory and rebuild the keys:
 
 ```
 cd circuits
 ./scripts/buildSnarksMedium.sh
+```
+
+### x32 Circuits
+Download [zkSNARK parameters](https://gateway.pinata.cloud/ipfs/QmWSxPBNYDtsK23KwYdMtcDaJg3gWS3LBsqMnENrVG6nmc) for 'x32' circuits into `circuits/params/` directory and rebuild the keys:
+
+```
+cd circuits
+./scripts/buildSnarks32.sh
 ```
 
 Recompile the contracts:
@@ -59,4 +69,23 @@ Verify:
 
 ```
 yarn ts-node scripts/verify.ts tally.json
+```
+
+### Note on x32 circuits
+
+Use v0.9.4 to install Zkutil use the script at maci/circuits/scripts/installZkutil.sh
+
+```
+./circuits/scripts/installZkutil.sh
+```
+
+x32 circuits are too large to compile down to wasm and use C instead to generate a binary. Should you find the need to recompile the binary from the C files generated in the trusted ceremony or recreate the QVT and BUST verifiers you may do so by running:
+
+Quadratic Vote Tally Verifier: 
+```
+sudo g++ -pthread main.cpp calcwit.cpp utils.cpp fr.cpp fr.o qvt32.c -o qvt32 -lgmp -std=c++11 -O3 -fopenmp -DSANITY_CHECK
+```
+BatchUst Verifier:
+```
+sudo g++ -pthread main.cpp calcwit.cpp utils.cpp fr.cpp fr.o batchUst.c -o batchUst -lgmp -std=c++11 -O3 -fopenmp -DSANITY_CHECK
 ```

--- a/docs/trusted-setup.md
+++ b/docs/trusted-setup.md
@@ -15,14 +15,6 @@ git checkout v0.9.4
 Follow instructions in README.md to install necessary dependencies.
 
 
-### Medium Circuits
-Download [zkSNARK parameters](https://gateway.pinata.cloud/ipfs/QmRzp3vkFPNHPpXiu7iKpPqVnZB97wq7gyih2mp6pa5bmD) for 'medium' circuits into `circuits/params/` directory and rebuild the keys:
-
-```
-cd circuits
-./scripts/buildSnarksMedium.sh
-```
-
 ### x32 Circuits
 Download [zkSNARK parameters](https://gateway.pinata.cloud/ipfs/QmWSxPBNYDtsK23KwYdMtcDaJg3gWS3LBsqMnENrVG6nmc) for 'x32' circuits into `circuits/params/` directory and rebuild the keys:
 
@@ -69,23 +61,4 @@ Verify:
 
 ```
 yarn ts-node scripts/verify.ts tally.json
-```
-
-### Note on x32 circuits
-
-Use v0.9.4 to install Zkutil use the script at maci/circuits/scripts/installZkutil.sh
-
-```
-./circuits/scripts/installZkutil.sh
-```
-
-x32 circuits are too large to compile down to wasm and use C instead to generate a binary. Should you find the need to recompile the binary from the C files generated in the trusted ceremony or recreate the QVT and BUST verifiers you may do so by running:
-
-Quadratic Vote Tally Verifier: 
-```
-sudo g++ -pthread main.cpp calcwit.cpp utils.cpp fr.cpp fr.o qvt32.c -o qvt32 -lgmp -std=c++11 -O3 -fopenmp -DSANITY_CHECK
-```
-BatchUst Verifier:
-```
-sudo g++ -pthread main.cpp calcwit.cpp utils.cpp fr.cpp fr.o batchUst.c -o batchUst -lgmp -std=c++11 -O3 -fopenmp -DSANITY_CHECK
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -3852,6 +3852,16 @@ cli-spinners@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.2.0.tgz#e8b988d9206c692302d8ee834e7a85c0144d8f77"
   integrity sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==
 
+cli-table3@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.0.tgz#b7b1bc65ca8e7b5cef9124e13dc2b21e2ce4faee"
+  integrity sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==
+  dependencies:
+    object-assign "^4.1.0"
+    string-width "^4.2.0"
+  optionalDependencies:
+    colors "^1.1.2"
+
 cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
@@ -4000,7 +4010,7 @@ colorette@^1.2.1:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
   integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
 
-colors@^1.4.0:
+colors@^1.1.2, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -7158,6 +7168,14 @@ har-validator@~5.1.3:
     ajv "^6.5.5"
     har-schema "^2.0.0"
 
+hardhat-contract-sizer@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/hardhat-contract-sizer/-/hardhat-contract-sizer-2.0.3.tgz#604455fd803865f81c29f60364e863eaa19395a7"
+  integrity sha512-iaixOzWxwOSIIE76cl2uk4m9VXI1hKU3bFt+gl7jDhyb2/JB2xOp5wECkfWqAoc4V5lD4JtjldZlpSTbzX+nPQ==
+  dependencies:
+    cli-table3 "^0.6.0"
+    colors "^1.4.0"
+
 hardhat@^2.0.11:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.0.11.tgz#f7bc9d38045ecda58665dcf1ffae9ff940712f06"
@@ -9306,10 +9324,10 @@ luxon@^1.26.0:
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.26.0.tgz#d3692361fda51473948252061d0f8561df02b578"
   integrity sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==
 
-maci-circuits@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/maci-circuits/-/maci-circuits-0.7.4.tgz#29b61c12577620db9db3b101d98ea05d8b430a7c"
-  integrity sha512-d+7v8mzKiiU+vkI+PFOwtdqa21Ehe/GTouhRrqWR7P+8DkenvxcN6GsU7EjPRC7e5lVuONnWXlj5xAt+K/7nZQ==
+maci-circuits@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/maci-circuits/-/maci-circuits-0.9.1.tgz#3b21e12f5b77f9f714eb36b7e407241bce77b39a"
+  integrity sha512-nS4ghYz0R5SjJpfwZXfsRzxLghFR5ANtEeDjJcmsUMQN4NPi7o5jV29Dtrdw2Y4Tc9s/W9pYgSRkNRX15F9MNQ==
   dependencies:
     argparse "^1.0.10"
     circom "0.5.38"
@@ -9318,34 +9336,35 @@ maci-circuits@^0.7.4:
     shelljs "^0.8.3"
     snarkjs "0.3.59"
 
-maci-cli@0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/maci-cli/-/maci-cli-0.7.4.tgz#a719bea29b998dc3213f40469762bf61fab6f1f4"
-  integrity sha512-TvuQ53ZRJTGG/1Ucx0Tw4rUx9URLxhYb0iyfEYMhu9Q7kSBsq4h5gVGVIzyd5ePbXGUzlCCvOONUl+QM7MOuPw==
+maci-cli@0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/maci-cli/-/maci-cli-0.9.4.tgz#59d7a64f12c0283c9b64f7c866eb0dc0e1db30e0"
+  integrity sha512-A+yLRDwIKhEaAcwg/VwHBMa727CgWGjWEUj+Dl35YmQroYNJ4CVVcl+EXlWWbhYQUES6izCmcHmH9jTbbRWT6w==
   dependencies:
     argparse "^1.0.10"
     ethers "^4.0.45"
-    maci-circuits "^0.7.4"
-    maci-config "^0.7.4"
-    maci-contracts "^0.7.4"
-    maci-core "^0.7.4"
-    maci-crypto "^0.7.4"
-    maci-domainobjs "^0.7.4"
+    maci-circuits "^0.9.1"
+    maci-config "^0.9.1"
+    maci-contracts "^0.9.4"
+    maci-core "^0.9.1"
+    maci-crypto "^0.9.1"
+    maci-domainobjs "^0.9.1"
     prompt-sync "4.2.0"
+    source-map-support "^0.5.19"
 
-maci-config@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/maci-config/-/maci-config-0.7.4.tgz#cee6129bef8d18d35f2d20775f991e310badd436"
-  integrity sha512-KvUuihOEt8kDmTxgKqd0P5kFqZ9nSQPupD/tqCizqZu7ESsWp50R7fw12Uj4JUpR2T/Ynbw+v1JwwWCXBGRROw==
+maci-config@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/maci-config/-/maci-config-0.9.1.tgz#d7d71a87800e5e5a7e2ce84fe4514fe53b2c14f1"
+  integrity sha512-Xkz4oTi2+Pw/z08aMePpjCXuNE+RgKoXgEsp6Ct8hqbgxHplBcOx6jJ5dAefb0c/yv/5AOF82zLIAJDt5Vi7jw==
   dependencies:
     config "^3.2.4"
     js-yaml "^3.13.1"
     path "^0.12.7"
 
-maci-contracts@0.7.4, maci-contracts@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/maci-contracts/-/maci-contracts-0.7.4.tgz#14510fcc09ba2d224062b14877729fb826911e2f"
-  integrity sha512-/dx/pou5vyC96bqYZp1tZhy1IWMeM3j8RnnKunE26KG7rMYvQDH+JRp95S+2V/wfLVs1BrXM3j26UeyR2Z8RRg==
+maci-contracts@0.9.4, maci-contracts@^0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/maci-contracts/-/maci-contracts-0.9.4.tgz#2ead408d4d1860ab5772db907eff77911645d60a"
+  integrity sha512-chLHaYQmkRHkb0tWjFArS9igf2j7W2cDKyFOYE+y+PXpYxI8NnKtY5nnX7u1z+qJwMBNa8sM7dvvshJBPQKgfw==
   dependencies:
     "@openzeppelin/contracts" "~3.2.0"
     argparse "^1.0.10"
@@ -9353,27 +9372,33 @@ maci-contracts@0.7.4, maci-contracts@^0.7.4:
     ethers "^4.0.45"
     module-alias "^2.2.2"
 
-maci-core@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/maci-core/-/maci-core-0.7.4.tgz#713cfb3884fe7f74543b790c8d2c2196f855a523"
-  integrity sha512-u6zrHjuWC1zlPpOHdvSGtX/J6HFKAbR8fYeQ5gXIQWuRF6MXPh/PIYcboTOU3DWMt7TQPplyqc52VuV1P8plQg==
+maci-core@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/maci-core/-/maci-core-0.9.1.tgz#c09cd148927ef42032378b1c16866fa687b705af"
+  integrity sha512-L8ngWftvyI1h3R+L0KVfcbiMAPVzpd3UyfjOlRQUWMFgK9CzbuF505Dkr1Yvhcv0a7O0mn54DiZfuArGdUJInQ==
   dependencies:
     ethers "^4.0.45"
-    maci-config "^0.7.4"
-    maci-crypto "^0.7.4"
-    maci-domainobjs "^0.7.4"
+    maci-config "^0.9.1"
+    maci-crypto "^0.9.1"
+    maci-domainobjs "^0.9.1"
     module-alias "^2.2.2"
 
-maci-crypto@^0.7.4, maci-crypto@~0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/maci-crypto/-/maci-crypto-0.7.4.tgz#6b9a518ff163da4e1aaea73bd6298206d99a0a5c"
-  integrity sha512-F7sdQJmgZO4nieFVjdhgbbOVF9lYUDp2gozNQ5V68fMaM3LQvDq6I8eAQ2bwYHo3xBcKmL8dKKliZ3Gn5kWXEw==
+maci-crypto@^0.9.1, maci-crypto@~0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/maci-crypto/-/maci-crypto-0.9.1.tgz#6127a53b0f7875bd5944d14825baf0bdd98f58ec"
+  integrity sha512-oSy/qqtfJaKLeJwHfeknrZFy99cvNZdrbZn0Eu5ZpC8o7BpVxtQmQmDrvx3sO1Ay1krE02YrCNeyyzB9LodKHw==
   dependencies:
+    blake-hash "^1.1.0"
     circomlib "0.5.1"
     ethers "^4.0.45"
     ffjavascript "0.2.35"
 
-maci-domainobjs@^0.7.4, maci-domainobjs@~0.7.4:
+maci-domainobjs@^0.9.1, maci-domainobjs@~0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/maci-domainobjs/-/maci-domainobjs-0.9.1.tgz#17b0c048c7030e32f4d21b71c7c1889558fd71c2"
+  integrity sha512-hTbYUbG8Oyi3ExyUpL2oi6QICY9jgJgoMsifJBL94k5kgeUWwQrwV+XvLcSndygt8XzQG3mWOIcA+s8yVnAUKw==
+
+maci-domainobjs@~0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/maci-domainobjs/-/maci-domainobjs-0.7.4.tgz#4574cae71e42cc889921bdc2ba268b0a109af658"
   integrity sha512-cpi6m2o6UrU0tr7og61hQb2sxdWkRih4g/3Ly6+BFEu9YBVaA6vbC9scmJYxTiTAKP8Xi6ozDUbZrLvubabvZw==
@@ -12891,7 +12916,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.11:
+source-map-support@^0.5.11, source-map-support@^0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==


### PR DESCRIPTION
uses circuts pinned [here](https://gateway.pinata.cloud/ipfs/QmWSxPBNYDtsK23KwYdMtcDaJg3gWS3LBsqMnENrVG6nmc), updates tests, track bytecode size, nuanced contract optimization. 

closes #367
closes #366 