### PR TITLE
Feature sponsorship fee

### DIFF
--- a/contracts/contracts/userRegistry/BrightIdUserRegistry.sol
+++ b/contracts/contracts/userRegistry/BrightIdUserRegistry.sol
@@ -81,7 +81,7 @@ contract BrightIdUserRegistry is Ownable, IUserRegistry {
      * @notice Set the address to receive fees
      * @param _feeRecipient Address to receive fees
     */
-    function setFee(address _feeRecipient) external onlyOwner {
+    function setFeeRecipient(address _feeRecipient) external onlyOwner {
         feeRecipient = _feeRecipient;
         emit SetFeeRecipient(feeRecipient);
     }

--- a/contracts/contracts/userRegistry/BrightIdUserRegistry.sol
+++ b/contracts/contracts/userRegistry/BrightIdUserRegistry.sol
@@ -48,7 +48,9 @@ contract BrightIdUserRegistry is Ownable, IUserRegistry {
      */
     function sponsor(address addr) public payable {
         require(msg.value == fee, ERROR_FEE_TO_LOW);
-        payable(feeRecipient).transfer(msg.value);
+        if (fee > 0) {
+            payable(feeRecipient).transfer(msg.value);
+        }
         emit Sponsor(addr);
     }
 

--- a/contracts/contracts/userRegistry/BrightIdUserRegistry.sol
+++ b/contracts/contracts/userRegistry/BrightIdUserRegistry.sol
@@ -10,7 +10,7 @@ contract BrightIdUserRegistry is Ownable, IUserRegistry {
     string private constant ERROR_NOT_AUTHORIZED = 'NOT AUTHORIZED';
     string private constant ERROR_INVALID_VERIFIER = 'INVALID VERIFIER';
     string private constant ERROR_INVALID_CONTEXT = 'INVALID CONTEXT';
-    string private constant ERROR_FEE_TO_LOW = 'FEE TO LOW';
+    string private constant ERROR_FEE_TOO_LOW = 'FEE TOO LOW';
 
     bytes32 public context;
     address public verifier;
@@ -33,12 +33,14 @@ contract BrightIdUserRegistry is Ownable, IUserRegistry {
      * @param _context BrightID context used for verifying users
      * @param _verifier BrightID verifier address that signs BrightID verifications
      */
-    constructor(bytes32 _context, address _verifier) public {
+    constructor(bytes32 _context, address _verifier, uint _fee, address _feeRecipient) public {
         // ecrecover returns zero on error
         require(_verifier != address(0), ERROR_INVALID_VERIFIER);
 
         context = _context;
         verifier = _verifier;
+        fee = _fee;
+        feeRecipient = _feeRecipient;
     }
 
     /**
@@ -47,7 +49,7 @@ contract BrightIdUserRegistry is Ownable, IUserRegistry {
      * @notice Requires transaction value to be equal to fee.
      */
     function sponsor(address addr) public payable {
-        require(msg.value == fee, ERROR_FEE_TO_LOW);
+        require(msg.value == fee, ERROR_FEE_TOO_LOW);
         if (fee > 0) {
             payable(feeRecipient).transfer(msg.value);
         }

--- a/vue-app/src/api/bright-id.ts
+++ b/vue-app/src/api/bright-id.ts
@@ -31,7 +31,7 @@ export async function selfSponsor(
   let overrides = {
     value: await registry.fee
   };
-  const transaction = await registry.sponsor(userAddress);
+  const transaction = await registry.sponsor(userAddress, overrides);
   return transaction;
 }
 

--- a/vue-app/src/api/bright-id.ts
+++ b/vue-app/src/api/bright-id.ts
@@ -1,37 +1,44 @@
-import { Contract, Signer } from 'ethers'
-import { TransactionResponse } from '@ethersproject/abstract-provider'
-import { formatBytes32String } from '@ethersproject/strings'
+import { Contract, Signer } from "ethers";
+import { TransactionResponse } from "@ethersproject/abstract-provider";
+import { formatBytes32String } from "@ethersproject/strings";
 
-import { BrightIdUserRegistry } from './abi'
-import { provider } from './core'
+import { BrightIdUserRegistry } from "./abi";
+import { provider } from "./core";
 
-const NODE_URL = 'https://app.brightid.org/node/v5'
-const CONTEXT = 'clr.fund'
+const NODE_URL = "https://app.brightid.org/node/v5";
+const CONTEXT = "clr.fund";
 
 export async function isSponsoredUser(
   registryAddress: string,
-  userAddress: string,
+  userAddress: string
 ): Promise<boolean> {
-  const registry = new Contract(registryAddress, BrightIdUserRegistry, provider)
-  const eventFilter = registry.filters.Sponsor(userAddress)
-  const events = await registry.queryFilter(eventFilter, 0)
-  return events.length > 0
+  const registry = new Contract(
+    registryAddress,
+    BrightIdUserRegistry,
+    provider
+  );
+  const eventFilter = registry.filters.Sponsor(userAddress);
+  const events = await registry.queryFilter(eventFilter, 0);
+  return events.length > 0;
 }
 
 export async function selfSponsor(
   registryAddress: string,
-  signer: Signer,
+  signer: Signer
 ): Promise<TransactionResponse> {
-  const registry = new Contract(registryAddress, BrightIdUserRegistry, signer)
-  const userAddress = await signer.getAddress()
-  const transaction = await registry.sponsor(userAddress)
-  return transaction
+  const registry = new Contract(registryAddress, BrightIdUserRegistry, signer);
+  const userAddress = await signer.getAddress();
+  let overrides = {
+    value: await registry.fee
+  };
+  const transaction = await registry.sponsor(userAddress);
+  return transaction;
 }
 
 export function getBrightIdLink(userAddress: string): string {
-  const nodeUrl = 'http:%2f%2fnode.brightid.org'
-  const deepLink = `brightid://link-verification/${nodeUrl}/${CONTEXT}/${userAddress}`
-  return deepLink
+  const nodeUrl = "http:%2f%2fnode.brightid.org";
+  const deepLink = `brightid://link-verification/${nodeUrl}/${CONTEXT}/${userAddress}`;
+  return deepLink;
 }
 
 export interface Verification {
@@ -42,42 +49,43 @@ export interface Verification {
 }
 
 export class BrightIdError extends Error {
-
-  code?: number
+  code?: number;
 
   constructor(code?: number) {
-    const message = code ? `BrightID error ${code}` : 'Unexpected error'
-    super(message)
+    const message = code ? `BrightID error ${code}` : "Unexpected error";
+    super(message);
     // https://github.com/Microsoft/TypeScript/issues/13965#issuecomment-388605613
-    Object.setPrototypeOf(this, BrightIdError.prototype)
-    this.code = code
+    Object.setPrototypeOf(this, BrightIdError.prototype);
+    this.code = code;
   }
 }
 
-export async function getVerification(userAddress: string): Promise<Verification | null> {
-  const apiUrl = `${NODE_URL}/verifications/clr.fund/${userAddress}?signed=eth&timestamp=seconds`
-  const response = await fetch(apiUrl)
-  const data = await response.json()
-  if (data['error']) {
-    throw new BrightIdError(data['errorNum'])
+export async function getVerification(
+  userAddress: string
+): Promise<Verification | null> {
+  const apiUrl = `${NODE_URL}/verifications/clr.fund/${userAddress}?signed=eth&timestamp=seconds`;
+  const response = await fetch(apiUrl);
+  const data = await response.json();
+  if (data["error"]) {
+    throw new BrightIdError(data["errorNum"]);
   } else {
-    return data['data']['unique'] ? data['data'] : null
+    return data["data"]["unique"] ? data["data"] : null;
   }
 }
 
 export async function registerUser(
   registryAddress: string,
   verification: Verification,
-  signer: Signer,
+  signer: Signer
 ): Promise<TransactionResponse> {
-  const registry = new Contract(registryAddress, BrightIdUserRegistry, signer)
+  const registry = new Contract(registryAddress, BrightIdUserRegistry, signer);
   const transaction = await registry.register(
     formatBytes32String(CONTEXT),
     verification.contextIds,
     verification.timestamp,
     verification.sig.v,
-    '0x' + verification.sig.r,
-    '0x' + verification.sig.s,
-  )
-  return transaction
+    "0x" + verification.sig.r,
+    "0x" + verification.sig.s
+  );
+  return transaction;
 }


### PR DESCRIPTION
This PR adds a `fee` and `feeRecipient` to the BrightIDUserRegistry, allowing contexts to set a fee that must be paid for self sponsorship. This mitigates the potential griefing attack in scenarios where the cost of a `sponsor()` call is lower than the cost of a sponsorship. The `fee` should be set to some value that is equal to or higher than the cost of a sponshorship. The `feeRecipient` could be set to the matching pool for a round, a funding source to the matching pool, or to some contract that buys sponsorships and allocates them to the same BrightID context.