### PR TITLE
Fix/contract test cases

### DIFF
--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -1,0 +1,26 @@
+name: Build and test contracts
+
+on: 
+  push:
+    paths:
+      - 'contracts/**'
+
+env:
+  NODE_VERSION: 12.x
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Use Node.js ${{ env.NODE_VERSION }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+    - name: Install
+      run: yarn
+    - name: Run tests
+      run: yarn test:contracts
+

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -1,9 +1,6 @@
 name: Build and test contracts
 
-on: 
-  push:
-    paths:
-      - 'contracts/**'
+on: push
 
 env:
   NODE_VERSION: 12.x

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -1,13 +1,15 @@
 name: Build and test contracts
 
-on: push
+on:
+  push:
+    paths:
+      - 'contracts/**'
 
 env:
   NODE_VERSION: 12.x
 
 jobs:
-
-  build:
+  test-contracts:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout


### PR DESCRIPTION
This PR fixes the test failures due to `removeRecipient()` expecting a baseDeposit.
It also updated the test case for `allow only owner to execute remove recipient request during challenge period`

 