### PR TITLE
Make `rounds` array public

### DIFF
--- a/contracts/contracts/FundingRoundFactory.sol
+++ b/contracts/contracts/FundingRoundFactory.sol
@@ -32,7 +32,7 @@ contract FundingRoundFactory is Ownable, MACISharedObjs {
   PubKey public coordinatorPubKey;
 
   EnumerableSet.AddressSet private fundingSources;
-  FundingRound[] private rounds;
+  FundingRound[] public rounds;
 
   // Events
   event FundingSourceAdded(address _source);


### PR DESCRIPTION
Make the `rounds` array public so that it can be easily queried by an RPC node.