### PR TITLE
Add VUE_APP_FIRST_ROUND to ignore old rounds

### DIFF
--- a/vue-app/.env.example
+++ b/vue-app/.env.example
@@ -30,6 +30,9 @@ VUE_APP_EXTRA_ROUNDS=
 # Operator of clr.fund instance
 VUE_APP_OPERATOR=
 
+# Index of first round to consider
+VUE_APP_FIRST_ROUND=
+
 # Google Service Account credentials in JSON format
 GOOGLE_APPLICATION_CREDENTIALS=
 # Spreadsheet ID to send recipients data

--- a/vue-app/src/api/round.ts
+++ b/vue-app/src/api/round.ts
@@ -58,7 +58,7 @@ export async function getCurrentRound(): Promise<string | null> {
     isSameAddress(round.address, fundingRoundAddress)
   )
 
-  if (roundIndex >= Number(process.env.VUE_APP_FIRST_ROUND)) {
+  if (roundIndex >= Number(process.env.VUE_APP_FIRST_ROUND || 0)) {
     return fundingRoundAddress
   }
   return null

--- a/vue-app/src/api/round.ts
+++ b/vue-app/src/api/round.ts
@@ -5,6 +5,9 @@ import { PubKey } from 'maci-domainobjs'
 import { FundingRound, MACI, ERC20 } from './abi'
 import { provider, factory } from './core'
 import { getTotalContributed } from './contributions'
+import { getRounds } from './rounds'
+
+import { isSameAddress } from '@/utils/accounts'
 
 export interface RoundInfo {
   fundingRoundAddress: string
@@ -50,7 +53,15 @@ export async function getCurrentRound(): Promise<string | null> {
   if (fundingRoundAddress === '0x0000000000000000000000000000000000000000') {
     return null
   }
-  return fundingRoundAddress
+  const rounds = await getRounds()
+  const roundIndex = rounds.findIndex((round) =>
+    isSameAddress(round.address, fundingRoundAddress)
+  )
+
+  if (roundIndex >= Number(process.env.VUE_APP_FIRST_ROUND)) {
+    return fundingRoundAddress
+  }
+  return null
 }
 
 //TODO: update to take factory address as a parameter, default to env. variable

--- a/vue-app/src/graphql/API.ts
+++ b/vue-app/src/graphql/API.ts
@@ -2505,7 +2505,7 @@ export const GetRecipientsDocument = gql`
     `;
 export const GetRoundsDocument = gql`
     query GetRounds {
-  fundingRounds {
+  fundingRounds(orderBy: startTime, orderDirection: asc) {
     id
   }
 }

--- a/vue-app/src/graphql/queries/GetRounds.graphql
+++ b/vue-app/src/graphql/queries/GetRounds.graphql
@@ -1,5 +1,5 @@
 query GetRounds {
-  fundingRounds {
+  fundingRounds(orderBy: startTime, orderDirection: asc) {
     id
   }
 }

--- a/vue-app/src/router/index.ts
+++ b/vue-app/src/router/index.ts
@@ -5,7 +5,6 @@ import Landing from '../views/Landing.vue'
 import JoinLanding from '../views/JoinLanding.vue'
 import ProjectList from '../views/ProjectList.vue'
 import ProjectView from '../views/Project.vue'
-import RoundList from '../views/RoundList.vue'
 import ProjectAdded from '../views/ProjectAdded.vue'
 import RoundInformation from '../views/RoundInformation.vue'
 import VerifyLanding from '../views/VerifyLanding.vue'
@@ -57,14 +56,6 @@ const routes = [
     component: RoundInformation,
     meta: {
       title: 'Round Information',
-    },
-  },
-  {
-    path: '/rounds',
-    name: 'rounds',
-    component: RoundList,
-    meta: {
-      title: 'Rounds',
     },
   },
   {


### PR DESCRIPTION
- Add `VUE_APP_FIRST_ROUND` to make it possible to ignore previous rounds, triggering the app into the "join phase"
- Remove the /rounds route, as it's not needed in this round