### PR TITLE
undefined chain.bridge error for non layer2

### DIFF
--- a/vue-app/src/views/Landing.vue
+++ b/vue-app/src/views/Landing.vue
@@ -93,10 +93,7 @@
               <b>{{ chain.label }} for fast and cheap transaction fees</b>
             </p>
           </div>
-          <links
-            :to="chain.isLayer2 ? '/about/layer-2' : chain.bridge"
-            class="btn-action"
-          >
+          <links v-if="chain.isLayer2" to="/about/layer-2" class="btn-action">
             Get {{ chain.label }} funds
           </links>
         </div>


### PR DESCRIPTION
When running the app on rinkeby, noticed the error in console log about undefined props for links.

The fix will remove the "get fund" button for non-layer2.

For layer2, it will redirect to the about layer2 page.. Not sure if it should go directly to the layer2 bridge or the about page.

Here's how it looks on the landing page.
<img width="1341" alt="Screen Shot 2022-03-08 at 10 04 33 PM" src="https://user-images.githubusercontent.com/18424940/157364828-2e79fe85-f05d-4197-a4ba-77db0f88438e.png">

