### PR TITLE
Add announcement link to round info

### DIFF
--- a/vue-app/src/components/RoundInformation.vue
+++ b/vue-app/src/components/RoundInformation.vue
@@ -273,11 +273,21 @@
         <div class="round-info-item">
           <div class="full-width">
             <div class="round-info-item-top">
-              <div class="round-info-title">No scheduled round</div>
+              <div class="round-info-title">Round not yet active</div>
             </div>
           </div>
-          <div class="round-info-value">
-            We haven't yet scheduled a funding round. Stay tuned!
+          <div class="round-announcement-info">
+            The funding round will open for contributions on May 6th!
+            <p>
+              <links to="https://blog.clr.fund/350k-eth-staking-qf-round/"
+                >Read the announcement post</links
+              >
+            </p>
+            <p>
+              <links to="/about/how-it-works/contributors"
+                >Prepare to contribute</links
+              >
+            </p>
           </div>
         </div>
       </template>
@@ -681,6 +691,42 @@ export default class RoundInformation extends Vue {
   flex-direction: row;
   align-items: flex-end;
 
+  .value {
+    font-size: 24px;
+    font-family: 'Glacial Indifference', sans-serif;
+    color: white;
+    font-weight: 700;
+    line-height: 120%;
+
+    &.large {
+      font-size: 32px;
+      line-height: 120%;
+    }
+
+    &.extra {
+      font-size: 32px;
+      font-family: 'Glacial Indifference', sans-serif;
+      color: white;
+      line-height: 120%;
+    }
+  }
+
+  .unit {
+    color: white;
+    font-family: 'Glacial Indifference', sans-serif;
+    font-size: 16px;
+    font-weight: 600;
+    text-transform: uppercase;
+    line-height: 150%;
+    margin: 0 0.5rem;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+}
+
+.round-announcement-info {
   .value {
     font-size: 24px;
     font-family: 'Glacial Indifference', sans-serif;


### PR DESCRIPTION
Update round info copy so it's more clear the round is coming.

### Before:
![Image 2022-04-19 at 8 19 44 AM](https://user-images.githubusercontent.com/8097623/163938658-e4eaf248-12e3-42aa-ab20-683e0cdad5b6.jpg)


### After:
![Image 2022-04-19 at 8 17 11 AM](https://user-images.githubusercontent.com/8097623/163938678-95b6af8f-37a0-4ff6-bc89-cbe715a9d5a8.jpg)

