### PR TITLE
Add optional ENV variable to customize matching pool

### DIFF
--- a/vue-app/.env.example
+++ b/vue-app/.env.example
@@ -19,6 +19,10 @@ VUE_APP_USER_REGISTRY_TYPE=simple
 # Learn more about BrightID and context in /docs/brightid.md
 VUE_APP_BRIGHTID_CONTEXT=clr.fund
 
+# Optional matching pool address to override the funding round factory address
+# e.g. if using a safe multisig for the matching pool
+VUE_APP_MATCHING_POOL_ADDRESS=
+
 # Supported values: simple, optimistic, kleros
 VUE_APP_RECIPIENT_REGISTRY_TYPE=simple
 

--- a/vue-app/src/api/round.ts
+++ b/vue-app/src/api/round.ts
@@ -154,14 +154,6 @@ export async function getRoundInfo(
     matchingPool = await factory.getMatchingFunds(nativeTokenAddress)
   }
 
-  // Hack to overwrite matching pool amount using designated address
-  if (nativeTokenAddress && process.env.VUE_APP_MATCHING_POOL_ADDRESS) {
-    matchingPool = await getTokenBalance(
-      nativeTokenAddress,
-      process.env.VUE_APP_MATCHING_POOL_ADDRESS
-    )
-  }
-
   const totalFunds = matchingPool.add(contributions)
 
   return {

--- a/vue-app/src/api/round.ts
+++ b/vue-app/src/api/round.ts
@@ -8,7 +8,6 @@ import { getTotalContributed } from './contributions'
 import { getRounds } from './rounds'
 
 import { isSameAddress } from '@/utils/accounts'
-import { getTokenBalance } from '@/api/user'
 
 export interface RoundInfo {
   fundingRoundAddress: string

--- a/vue-app/src/api/round.ts
+++ b/vue-app/src/api/round.ts
@@ -8,6 +8,7 @@ import { getTotalContributed } from './contributions'
 import { getRounds } from './rounds'
 
 import { isSameAddress } from '@/utils/accounts'
+import { getTokenBalance } from '@/api/user'
 
 export interface RoundInfo {
   fundingRoundAddress: string
@@ -151,6 +152,14 @@ export async function getRoundInfo(
     contributions = contributionsInfo.amount
     //TODO: update to take factory address as a parameter, default to env. variable
     matchingPool = await factory.getMatchingFunds(nativeTokenAddress)
+  }
+
+  // Hack to overwrite matching pool amount using designated address
+  if (nativeTokenAddress && process.env.VUE_APP_MATCHING_POOL_ADDRESS) {
+    matchingPool = await getTokenBalance(
+      nativeTokenAddress,
+      process.env.VUE_APP_MATCHING_POOL_ADDRESS
+    )
   }
 
   const totalFunds = matchingPool.add(contributions)

--- a/vue-app/src/components/MatchingFundsModal.vue
+++ b/vue-app/src/components/MatchingFundsModal.vue
@@ -162,10 +162,15 @@ export default class MatchingFundsModal extends Vue {
       this.$store.state.currentRound
     const token = new Contract(nativeTokenAddress, ERC20, this.signer)
     const amount = parseFixed(this.amount, nativeTokenDecimals)
+
+    // TODO: update to take factory address as a parameter from the route props, default to env. variable
+    const matchingPoolAddress = process.env.VUE_APP_MATCHING_POOL_ADDRESS
+      ? process.env.VUE_APP_MATCHING_POOL_ADDRESS
+      : factory.address
+
     try {
       await waitForTransaction(
-        //TODO: update to take factory address as a parameter from the route props, default to env. variable
-        token.transfer(factory.address, amount),
+        token.transfer(matchingPoolAddress, amount),
         (hash) => (this.transferTxHash = hash)
       )
     } catch (error) {


### PR DESCRIPTION

Request from @auryn-macmillan 

> I'd like to change it so that when people hit the button to contribute funds to the matching pool, it goes to the matching pool safe rather than the funding round factory.
That way, if for some reason we have a hiccup in the round, we don't have to do any wrangling to recover those funds.

This provides an optional ENV variable that would override the address where contributions to the matching pool are transferred to.