### PR TITLE
Fix condition to check if the round has started

### DIFF
--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -51,7 +51,7 @@
           <li>Access to Zoom or Google Meet</li>
         </ul>
         <links to="/about/sybil-resistance">Why is this important?</links>
-        <div v-if="isRoundNotStarted" class="join-message">
+        <div v-if="!hasRoundStarted" class="join-message">
           There's not yet an open funding round. Get prepared now so you're
           ready for when the next one begins!
         </div>
@@ -131,8 +131,8 @@ export default class VerifyLanding extends Vue {
     return commify(formatUnits(balance, 18))
   }
 
-  get isRoundNotStarted(): boolean {
-    return this.$store.getters.isRoundJoinPhase
+  get hasRoundStarted(): boolean {
+    return !!this.currentRound
   }
 
   get isRoundFull(): boolean {


### PR DESCRIPTION
We are displaying (in https://qf.ethstaker.cc/#/verify) the following message incorrectly since the round has already started.
![bug](https://user-images.githubusercontent.com/468158/167703365-b79f01f6-55ef-4b35-97d2-373e340bc699.png)

This was because we were assuming that the round was not started if we were in the join phase. But we can be in the join phase while the round is open.

To check if the round has started we just check if there is a current round.