### PR TITLE
Make Project Detail content responsive

### DIFF
--- a/vue-app/src/components/Markdown.vue
+++ b/vue-app/src/components/Markdown.vue
@@ -38,6 +38,14 @@ export default class Transaction extends Vue {
     p {
       line-height: 150%;
     }
+    img {
+      display: block;
+      max-width: 100%;
+      height: auto;
+    }
+    pre {
+      white-space: pre-wrap;
+    }
   }
 }
 </style>


### PR DESCRIPTION
Adjust markdown images and `<pre>` code to be able to shrink the container.

fixes #488 