### PR TITLE
only render brightid link if available

### DIFF
--- a/vue-app/src/views/Verify.vue
+++ b/vue-app/src/views/Verify.vue
@@ -109,7 +109,7 @@
               verify the connection - please wait.
             </p>
             <div class="qr">
-              <div class="instructions">
+              <div class="instructions" v-if="appLink">
                 <p class="desktop" v-if="appLinkQrCode">
                   Scan this QR code with your BrightID app
                 </p>


### PR DESCRIPTION
This PR fixes the 404 page not found error when the brightid link is clicked in the mobile mode.

The link is rendered before the `appLink` is set, so, it's rendered as `router-link` instead of an external link causing the page not found error.