### PR TITLE
Fetch round contributions balance from the contract

### DIFF
--- a/vue-app/src/api/contributions.ts
+++ b/vue-app/src/api/contributions.ts
@@ -2,7 +2,8 @@ import { BigNumber, Contract, Signer } from 'ethers'
 import { TransactionResponse } from '@ethersproject/abstract-provider'
 import { Keypair, PrivKey } from 'maci-domainobjs'
 
-import { FundingRound } from './abi'
+import { FundingRound, ERC20 } from './abi'
+import { factory, provider } from './core'
 import { Project } from './projects'
 import sdk from '@/graphql/sdk'
 
@@ -86,29 +87,21 @@ export async function getContributionAmount(
 export async function getTotalContributed(
   fundingRoundAddress: string
 ): Promise<{ count: number; amount: BigNumber }> {
+  const nativeTokenAddress = await factory.nativeToken()
+  const nativeToken = new Contract(nativeTokenAddress, ERC20, provider)
+  const balance = await nativeToken.balanceOf(fundingRoundAddress)
+
   const data = await sdk.GetTotalContributed({
     fundingRoundAddress: fundingRoundAddress.toLowerCase(),
   })
 
-  if (!data.fundingRound?.contributors) {
+  if (!data.fundingRound?.contributorCount) {
     return { count: 0, amount: BigNumber.from(0) }
   }
 
   const count = parseInt(data.fundingRound.contributorCount)
 
-  const amount = data.fundingRound.contributors.reduce((total, contributor) => {
-    if (!contributor.contributions?.length) {
-      return total
-    }
-
-    const subtotal = contributor.contributions.reduce((total, contribution) => {
-      return total.add(contribution.amount)
-    }, BigNumber.from(0))
-
-    return total.add(subtotal)
-  }, BigNumber.from(0))
-
-  return { count, amount }
+  return { count, amount: balance }
 }
 
 export async function withdrawContribution(

--- a/vue-app/src/graphql/API.ts
+++ b/vue-app/src/graphql/API.ts
@@ -22,6 +22,10 @@ export type Scalars = {
 
 
 
+export type BlockChangedFilter = {
+  number_gte: Scalars['Int'];
+};
+
 export type Block_Height = {
   hash: Maybe<Scalars['Bytes']>;
   number: Maybe<Scalars['Int']>;
@@ -57,11 +61,17 @@ export type Contribution_Filter = {
   contributor_in: Maybe<Array<Scalars['String']>>;
   contributor_not_in: Maybe<Array<Scalars['String']>>;
   contributor_contains: Maybe<Scalars['String']>;
+  contributor_contains_nocase: Maybe<Scalars['String']>;
   contributor_not_contains: Maybe<Scalars['String']>;
+  contributor_not_contains_nocase: Maybe<Scalars['String']>;
   contributor_starts_with: Maybe<Scalars['String']>;
+  contributor_starts_with_nocase: Maybe<Scalars['String']>;
   contributor_not_starts_with: Maybe<Scalars['String']>;
+  contributor_not_starts_with_nocase: Maybe<Scalars['String']>;
   contributor_ends_with: Maybe<Scalars['String']>;
+  contributor_ends_with_nocase: Maybe<Scalars['String']>;
   contributor_not_ends_with: Maybe<Scalars['String']>;
+  contributor_not_ends_with_nocase: Maybe<Scalars['String']>;
   fundingRound: Maybe<Scalars['String']>;
   fundingRound_not: Maybe<Scalars['String']>;
   fundingRound_gt: Maybe<Scalars['String']>;
@@ -71,11 +81,17 @@ export type Contribution_Filter = {
   fundingRound_in: Maybe<Array<Scalars['String']>>;
   fundingRound_not_in: Maybe<Array<Scalars['String']>>;
   fundingRound_contains: Maybe<Scalars['String']>;
+  fundingRound_contains_nocase: Maybe<Scalars['String']>;
   fundingRound_not_contains: Maybe<Scalars['String']>;
+  fundingRound_not_contains_nocase: Maybe<Scalars['String']>;
   fundingRound_starts_with: Maybe<Scalars['String']>;
+  fundingRound_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRound_not_starts_with: Maybe<Scalars['String']>;
+  fundingRound_not_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRound_ends_with: Maybe<Scalars['String']>;
+  fundingRound_ends_with_nocase: Maybe<Scalars['String']>;
   fundingRound_not_ends_with: Maybe<Scalars['String']>;
+  fundingRound_not_ends_with_nocase: Maybe<Scalars['String']>;
   amount: Maybe<Scalars['BigInt']>;
   amount_not: Maybe<Scalars['BigInt']>;
   amount_gt: Maybe<Scalars['BigInt']>;
@@ -101,11 +117,19 @@ export type Contribution_Filter = {
   createdAt_in: Maybe<Array<Scalars['String']>>;
   createdAt_not_in: Maybe<Array<Scalars['String']>>;
   createdAt_contains: Maybe<Scalars['String']>;
+  createdAt_contains_nocase: Maybe<Scalars['String']>;
   createdAt_not_contains: Maybe<Scalars['String']>;
+  createdAt_not_contains_nocase: Maybe<Scalars['String']>;
   createdAt_starts_with: Maybe<Scalars['String']>;
+  createdAt_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_starts_with: Maybe<Scalars['String']>;
+  createdAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_ends_with: Maybe<Scalars['String']>;
+  createdAt_ends_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_ends_with: Maybe<Scalars['String']>;
+  createdAt_not_ends_with_nocase: Maybe<Scalars['String']>;
+  /** Filter for the block changed event. */
+  _change_block: Maybe<BlockChangedFilter>;
 };
 
 export enum Contribution_OrderBy {
@@ -196,11 +220,17 @@ export type ContributorRegistry_Filter = {
   fundingRoundFactory_in: Maybe<Array<Scalars['String']>>;
   fundingRoundFactory_not_in: Maybe<Array<Scalars['String']>>;
   fundingRoundFactory_contains: Maybe<Scalars['String']>;
+  fundingRoundFactory_contains_nocase: Maybe<Scalars['String']>;
   fundingRoundFactory_not_contains: Maybe<Scalars['String']>;
+  fundingRoundFactory_not_contains_nocase: Maybe<Scalars['String']>;
   fundingRoundFactory_starts_with: Maybe<Scalars['String']>;
+  fundingRoundFactory_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRoundFactory_not_starts_with: Maybe<Scalars['String']>;
+  fundingRoundFactory_not_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRoundFactory_ends_with: Maybe<Scalars['String']>;
+  fundingRoundFactory_ends_with_nocase: Maybe<Scalars['String']>;
   fundingRoundFactory_not_ends_with: Maybe<Scalars['String']>;
+  fundingRoundFactory_not_ends_with_nocase: Maybe<Scalars['String']>;
   context: Maybe<Scalars['String']>;
   context_not: Maybe<Scalars['String']>;
   context_gt: Maybe<Scalars['String']>;
@@ -210,11 +240,17 @@ export type ContributorRegistry_Filter = {
   context_in: Maybe<Array<Scalars['String']>>;
   context_not_in: Maybe<Array<Scalars['String']>>;
   context_contains: Maybe<Scalars['String']>;
+  context_contains_nocase: Maybe<Scalars['String']>;
   context_not_contains: Maybe<Scalars['String']>;
+  context_not_contains_nocase: Maybe<Scalars['String']>;
   context_starts_with: Maybe<Scalars['String']>;
+  context_starts_with_nocase: Maybe<Scalars['String']>;
   context_not_starts_with: Maybe<Scalars['String']>;
+  context_not_starts_with_nocase: Maybe<Scalars['String']>;
   context_ends_with: Maybe<Scalars['String']>;
+  context_ends_with_nocase: Maybe<Scalars['String']>;
   context_not_ends_with: Maybe<Scalars['String']>;
+  context_not_ends_with_nocase: Maybe<Scalars['String']>;
   owner: Maybe<Scalars['Bytes']>;
   owner_not: Maybe<Scalars['Bytes']>;
   owner_in: Maybe<Array<Scalars['Bytes']>>;
@@ -230,11 +266,17 @@ export type ContributorRegistry_Filter = {
   createdAt_in: Maybe<Array<Scalars['String']>>;
   createdAt_not_in: Maybe<Array<Scalars['String']>>;
   createdAt_contains: Maybe<Scalars['String']>;
+  createdAt_contains_nocase: Maybe<Scalars['String']>;
   createdAt_not_contains: Maybe<Scalars['String']>;
+  createdAt_not_contains_nocase: Maybe<Scalars['String']>;
   createdAt_starts_with: Maybe<Scalars['String']>;
+  createdAt_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_starts_with: Maybe<Scalars['String']>;
+  createdAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_ends_with: Maybe<Scalars['String']>;
+  createdAt_ends_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_ends_with: Maybe<Scalars['String']>;
+  createdAt_not_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt: Maybe<Scalars['String']>;
   lastUpdatedAt_not: Maybe<Scalars['String']>;
   lastUpdatedAt_gt: Maybe<Scalars['String']>;
@@ -244,11 +286,19 @@ export type ContributorRegistry_Filter = {
   lastUpdatedAt_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_not_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_ends_with_nocase: Maybe<Scalars['String']>;
+  /** Filter for the block changed event. */
+  _change_block: Maybe<BlockChangedFilter>;
 };
 
 export enum ContributorRegistry_OrderBy {
@@ -279,11 +329,17 @@ export type Contributor_Filter = {
   contributorRegistry_in: Maybe<Array<Scalars['String']>>;
   contributorRegistry_not_in: Maybe<Array<Scalars['String']>>;
   contributorRegistry_contains: Maybe<Scalars['String']>;
+  contributorRegistry_contains_nocase: Maybe<Scalars['String']>;
   contributorRegistry_not_contains: Maybe<Scalars['String']>;
+  contributorRegistry_not_contains_nocase: Maybe<Scalars['String']>;
   contributorRegistry_starts_with: Maybe<Scalars['String']>;
+  contributorRegistry_starts_with_nocase: Maybe<Scalars['String']>;
   contributorRegistry_not_starts_with: Maybe<Scalars['String']>;
+  contributorRegistry_not_starts_with_nocase: Maybe<Scalars['String']>;
   contributorRegistry_ends_with: Maybe<Scalars['String']>;
+  contributorRegistry_ends_with_nocase: Maybe<Scalars['String']>;
   contributorRegistry_not_ends_with: Maybe<Scalars['String']>;
+  contributorRegistry_not_ends_with_nocase: Maybe<Scalars['String']>;
   verified: Maybe<Scalars['Boolean']>;
   verified_not: Maybe<Scalars['Boolean']>;
   verified_in: Maybe<Array<Scalars['Boolean']>>;
@@ -297,11 +353,17 @@ export type Contributor_Filter = {
   verifiedTimeStamp_in: Maybe<Array<Scalars['String']>>;
   verifiedTimeStamp_not_in: Maybe<Array<Scalars['String']>>;
   verifiedTimeStamp_contains: Maybe<Scalars['String']>;
+  verifiedTimeStamp_contains_nocase: Maybe<Scalars['String']>;
   verifiedTimeStamp_not_contains: Maybe<Scalars['String']>;
+  verifiedTimeStamp_not_contains_nocase: Maybe<Scalars['String']>;
   verifiedTimeStamp_starts_with: Maybe<Scalars['String']>;
+  verifiedTimeStamp_starts_with_nocase: Maybe<Scalars['String']>;
   verifiedTimeStamp_not_starts_with: Maybe<Scalars['String']>;
+  verifiedTimeStamp_not_starts_with_nocase: Maybe<Scalars['String']>;
   verifiedTimeStamp_ends_with: Maybe<Scalars['String']>;
+  verifiedTimeStamp_ends_with_nocase: Maybe<Scalars['String']>;
   verifiedTimeStamp_not_ends_with: Maybe<Scalars['String']>;
+  verifiedTimeStamp_not_ends_with_nocase: Maybe<Scalars['String']>;
   contributorAddress: Maybe<Scalars['Bytes']>;
   contributorAddress_not: Maybe<Scalars['Bytes']>;
   contributorAddress_in: Maybe<Array<Scalars['Bytes']>>;
@@ -311,7 +373,9 @@ export type Contributor_Filter = {
   fundingRounds: Maybe<Array<Scalars['String']>>;
   fundingRounds_not: Maybe<Array<Scalars['String']>>;
   fundingRounds_contains: Maybe<Array<Scalars['String']>>;
+  fundingRounds_contains_nocase: Maybe<Array<Scalars['String']>>;
   fundingRounds_not_contains: Maybe<Array<Scalars['String']>>;
+  fundingRounds_not_contains_nocase: Maybe<Array<Scalars['String']>>;
   createdAt: Maybe<Scalars['String']>;
   createdAt_not: Maybe<Scalars['String']>;
   createdAt_gt: Maybe<Scalars['String']>;
@@ -321,11 +385,17 @@ export type Contributor_Filter = {
   createdAt_in: Maybe<Array<Scalars['String']>>;
   createdAt_not_in: Maybe<Array<Scalars['String']>>;
   createdAt_contains: Maybe<Scalars['String']>;
+  createdAt_contains_nocase: Maybe<Scalars['String']>;
   createdAt_not_contains: Maybe<Scalars['String']>;
+  createdAt_not_contains_nocase: Maybe<Scalars['String']>;
   createdAt_starts_with: Maybe<Scalars['String']>;
+  createdAt_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_starts_with: Maybe<Scalars['String']>;
+  createdAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_ends_with: Maybe<Scalars['String']>;
+  createdAt_ends_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_ends_with: Maybe<Scalars['String']>;
+  createdAt_not_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt: Maybe<Scalars['String']>;
   lastUpdatedAt_not: Maybe<Scalars['String']>;
   lastUpdatedAt_gt: Maybe<Scalars['String']>;
@@ -335,11 +405,19 @@ export type Contributor_Filter = {
   lastUpdatedAt_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_not_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_ends_with_nocase: Maybe<Scalars['String']>;
+  /** Filter for the block changed event. */
+  _change_block: Maybe<BlockChangedFilter>;
 };
 
 export enum Contributor_OrderBy {
@@ -381,11 +459,17 @@ export type Coordinator_Filter = {
   contact_in: Maybe<Array<Scalars['String']>>;
   contact_not_in: Maybe<Array<Scalars['String']>>;
   contact_contains: Maybe<Scalars['String']>;
+  contact_contains_nocase: Maybe<Scalars['String']>;
   contact_not_contains: Maybe<Scalars['String']>;
+  contact_not_contains_nocase: Maybe<Scalars['String']>;
   contact_starts_with: Maybe<Scalars['String']>;
+  contact_starts_with_nocase: Maybe<Scalars['String']>;
   contact_not_starts_with: Maybe<Scalars['String']>;
+  contact_not_starts_with_nocase: Maybe<Scalars['String']>;
   contact_ends_with: Maybe<Scalars['String']>;
+  contact_ends_with_nocase: Maybe<Scalars['String']>;
   contact_not_ends_with: Maybe<Scalars['String']>;
+  contact_not_ends_with_nocase: Maybe<Scalars['String']>;
   createdAt: Maybe<Scalars['String']>;
   createdAt_not: Maybe<Scalars['String']>;
   createdAt_gt: Maybe<Scalars['String']>;
@@ -395,11 +479,17 @@ export type Coordinator_Filter = {
   createdAt_in: Maybe<Array<Scalars['String']>>;
   createdAt_not_in: Maybe<Array<Scalars['String']>>;
   createdAt_contains: Maybe<Scalars['String']>;
+  createdAt_contains_nocase: Maybe<Scalars['String']>;
   createdAt_not_contains: Maybe<Scalars['String']>;
+  createdAt_not_contains_nocase: Maybe<Scalars['String']>;
   createdAt_starts_with: Maybe<Scalars['String']>;
+  createdAt_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_starts_with: Maybe<Scalars['String']>;
+  createdAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_ends_with: Maybe<Scalars['String']>;
+  createdAt_ends_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_ends_with: Maybe<Scalars['String']>;
+  createdAt_not_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt: Maybe<Scalars['String']>;
   lastUpdatedAt_not: Maybe<Scalars['String']>;
   lastUpdatedAt_gt: Maybe<Scalars['String']>;
@@ -409,11 +499,19 @@ export type Coordinator_Filter = {
   lastUpdatedAt_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_not_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_ends_with_nocase: Maybe<Scalars['String']>;
+  /** Filter for the block changed event. */
+  _change_block: Maybe<BlockChangedFilter>;
 };
 
 export enum Coordinator_OrderBy {
@@ -451,11 +549,17 @@ export type Donation_Filter = {
   recipient_in: Maybe<Array<Scalars['String']>>;
   recipient_not_in: Maybe<Array<Scalars['String']>>;
   recipient_contains: Maybe<Scalars['String']>;
+  recipient_contains_nocase: Maybe<Scalars['String']>;
   recipient_not_contains: Maybe<Scalars['String']>;
+  recipient_not_contains_nocase: Maybe<Scalars['String']>;
   recipient_starts_with: Maybe<Scalars['String']>;
+  recipient_starts_with_nocase: Maybe<Scalars['String']>;
   recipient_not_starts_with: Maybe<Scalars['String']>;
+  recipient_not_starts_with_nocase: Maybe<Scalars['String']>;
   recipient_ends_with: Maybe<Scalars['String']>;
+  recipient_ends_with_nocase: Maybe<Scalars['String']>;
   recipient_not_ends_with: Maybe<Scalars['String']>;
+  recipient_not_ends_with_nocase: Maybe<Scalars['String']>;
   fundingRound: Maybe<Scalars['String']>;
   fundingRound_not: Maybe<Scalars['String']>;
   fundingRound_gt: Maybe<Scalars['String']>;
@@ -465,11 +569,17 @@ export type Donation_Filter = {
   fundingRound_in: Maybe<Array<Scalars['String']>>;
   fundingRound_not_in: Maybe<Array<Scalars['String']>>;
   fundingRound_contains: Maybe<Scalars['String']>;
+  fundingRound_contains_nocase: Maybe<Scalars['String']>;
   fundingRound_not_contains: Maybe<Scalars['String']>;
+  fundingRound_not_contains_nocase: Maybe<Scalars['String']>;
   fundingRound_starts_with: Maybe<Scalars['String']>;
+  fundingRound_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRound_not_starts_with: Maybe<Scalars['String']>;
+  fundingRound_not_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRound_ends_with: Maybe<Scalars['String']>;
+  fundingRound_ends_with_nocase: Maybe<Scalars['String']>;
   fundingRound_not_ends_with: Maybe<Scalars['String']>;
+  fundingRound_not_ends_with_nocase: Maybe<Scalars['String']>;
   amount: Maybe<Scalars['BigInt']>;
   amount_not: Maybe<Scalars['BigInt']>;
   amount_gt: Maybe<Scalars['BigInt']>;
@@ -495,11 +605,19 @@ export type Donation_Filter = {
   createdAt_in: Maybe<Array<Scalars['String']>>;
   createdAt_not_in: Maybe<Array<Scalars['String']>>;
   createdAt_contains: Maybe<Scalars['String']>;
+  createdAt_contains_nocase: Maybe<Scalars['String']>;
   createdAt_not_contains: Maybe<Scalars['String']>;
+  createdAt_not_contains_nocase: Maybe<Scalars['String']>;
   createdAt_starts_with: Maybe<Scalars['String']>;
+  createdAt_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_starts_with: Maybe<Scalars['String']>;
+  createdAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_ends_with: Maybe<Scalars['String']>;
+  createdAt_ends_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_ends_with: Maybe<Scalars['String']>;
+  createdAt_not_ends_with_nocase: Maybe<Scalars['String']>;
+  /** Filter for the block changed event. */
+  _change_block: Maybe<BlockChangedFilter>;
 };
 
 export enum Donation_OrderBy {
@@ -663,11 +781,17 @@ export type FundingRoundFactory_Filter = {
   contributorRegistry_in: Maybe<Array<Scalars['String']>>;
   contributorRegistry_not_in: Maybe<Array<Scalars['String']>>;
   contributorRegistry_contains: Maybe<Scalars['String']>;
+  contributorRegistry_contains_nocase: Maybe<Scalars['String']>;
   contributorRegistry_not_contains: Maybe<Scalars['String']>;
+  contributorRegistry_not_contains_nocase: Maybe<Scalars['String']>;
   contributorRegistry_starts_with: Maybe<Scalars['String']>;
+  contributorRegistry_starts_with_nocase: Maybe<Scalars['String']>;
   contributorRegistry_not_starts_with: Maybe<Scalars['String']>;
+  contributorRegistry_not_starts_with_nocase: Maybe<Scalars['String']>;
   contributorRegistry_ends_with: Maybe<Scalars['String']>;
+  contributorRegistry_ends_with_nocase: Maybe<Scalars['String']>;
   contributorRegistry_not_ends_with: Maybe<Scalars['String']>;
+  contributorRegistry_not_ends_with_nocase: Maybe<Scalars['String']>;
   contributorRegistryAddress: Maybe<Scalars['Bytes']>;
   contributorRegistryAddress_not: Maybe<Scalars['Bytes']>;
   contributorRegistryAddress_in: Maybe<Array<Scalars['Bytes']>>;
@@ -683,11 +807,17 @@ export type FundingRoundFactory_Filter = {
   recipientRegistry_in: Maybe<Array<Scalars['String']>>;
   recipientRegistry_not_in: Maybe<Array<Scalars['String']>>;
   recipientRegistry_contains: Maybe<Scalars['String']>;
+  recipientRegistry_contains_nocase: Maybe<Scalars['String']>;
   recipientRegistry_not_contains: Maybe<Scalars['String']>;
+  recipientRegistry_not_contains_nocase: Maybe<Scalars['String']>;
   recipientRegistry_starts_with: Maybe<Scalars['String']>;
+  recipientRegistry_starts_with_nocase: Maybe<Scalars['String']>;
   recipientRegistry_not_starts_with: Maybe<Scalars['String']>;
+  recipientRegistry_not_starts_with_nocase: Maybe<Scalars['String']>;
   recipientRegistry_ends_with: Maybe<Scalars['String']>;
+  recipientRegistry_ends_with_nocase: Maybe<Scalars['String']>;
   recipientRegistry_not_ends_with: Maybe<Scalars['String']>;
+  recipientRegistry_not_ends_with_nocase: Maybe<Scalars['String']>;
   recipientRegistryAddress: Maybe<Scalars['Bytes']>;
   recipientRegistryAddress_not: Maybe<Scalars['Bytes']>;
   recipientRegistryAddress_in: Maybe<Array<Scalars['Bytes']>>;
@@ -703,11 +833,17 @@ export type FundingRoundFactory_Filter = {
   currentRound_in: Maybe<Array<Scalars['String']>>;
   currentRound_not_in: Maybe<Array<Scalars['String']>>;
   currentRound_contains: Maybe<Scalars['String']>;
+  currentRound_contains_nocase: Maybe<Scalars['String']>;
   currentRound_not_contains: Maybe<Scalars['String']>;
+  currentRound_not_contains_nocase: Maybe<Scalars['String']>;
   currentRound_starts_with: Maybe<Scalars['String']>;
+  currentRound_starts_with_nocase: Maybe<Scalars['String']>;
   currentRound_not_starts_with: Maybe<Scalars['String']>;
+  currentRound_not_starts_with_nocase: Maybe<Scalars['String']>;
   currentRound_ends_with: Maybe<Scalars['String']>;
+  currentRound_ends_with_nocase: Maybe<Scalars['String']>;
   currentRound_not_ends_with: Maybe<Scalars['String']>;
+  currentRound_not_ends_with_nocase: Maybe<Scalars['String']>;
   maciFactory: Maybe<Scalars['Bytes']>;
   maciFactory_not: Maybe<Scalars['Bytes']>;
   maciFactory_in: Maybe<Array<Scalars['Bytes']>>;
@@ -723,11 +859,17 @@ export type FundingRoundFactory_Filter = {
   coordinatorPubKey_in: Maybe<Array<Scalars['String']>>;
   coordinatorPubKey_not_in: Maybe<Array<Scalars['String']>>;
   coordinatorPubKey_contains: Maybe<Scalars['String']>;
+  coordinatorPubKey_contains_nocase: Maybe<Scalars['String']>;
   coordinatorPubKey_not_contains: Maybe<Scalars['String']>;
+  coordinatorPubKey_not_contains_nocase: Maybe<Scalars['String']>;
   coordinatorPubKey_starts_with: Maybe<Scalars['String']>;
+  coordinatorPubKey_starts_with_nocase: Maybe<Scalars['String']>;
   coordinatorPubKey_not_starts_with: Maybe<Scalars['String']>;
+  coordinatorPubKey_not_starts_with_nocase: Maybe<Scalars['String']>;
   coordinatorPubKey_ends_with: Maybe<Scalars['String']>;
+  coordinatorPubKey_ends_with_nocase: Maybe<Scalars['String']>;
   coordinatorPubKey_not_ends_with: Maybe<Scalars['String']>;
+  coordinatorPubKey_not_ends_with_nocase: Maybe<Scalars['String']>;
   stateTreeDepth: Maybe<Scalars['BigInt']>;
   stateTreeDepth_not: Maybe<Scalars['BigInt']>;
   stateTreeDepth_gt: Maybe<Scalars['BigInt']>;
@@ -829,11 +971,17 @@ export type FundingRoundFactory_Filter = {
   createdAt_in: Maybe<Array<Scalars['String']>>;
   createdAt_not_in: Maybe<Array<Scalars['String']>>;
   createdAt_contains: Maybe<Scalars['String']>;
+  createdAt_contains_nocase: Maybe<Scalars['String']>;
   createdAt_not_contains: Maybe<Scalars['String']>;
+  createdAt_not_contains_nocase: Maybe<Scalars['String']>;
   createdAt_starts_with: Maybe<Scalars['String']>;
+  createdAt_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_starts_with: Maybe<Scalars['String']>;
+  createdAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_ends_with: Maybe<Scalars['String']>;
+  createdAt_ends_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_ends_with: Maybe<Scalars['String']>;
+  createdAt_not_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt: Maybe<Scalars['String']>;
   lastUpdatedAt_not: Maybe<Scalars['String']>;
   lastUpdatedAt_gt: Maybe<Scalars['String']>;
@@ -843,11 +991,19 @@ export type FundingRoundFactory_Filter = {
   lastUpdatedAt_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_not_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_ends_with_nocase: Maybe<Scalars['String']>;
+  /** Filter for the block changed event. */
+  _change_block: Maybe<BlockChangedFilter>;
 };
 
 export enum FundingRoundFactory_OrderBy {
@@ -897,11 +1053,17 @@ export type FundingRound_Filter = {
   fundingRoundFactory_in: Maybe<Array<Scalars['String']>>;
   fundingRoundFactory_not_in: Maybe<Array<Scalars['String']>>;
   fundingRoundFactory_contains: Maybe<Scalars['String']>;
+  fundingRoundFactory_contains_nocase: Maybe<Scalars['String']>;
   fundingRoundFactory_not_contains: Maybe<Scalars['String']>;
+  fundingRoundFactory_not_contains_nocase: Maybe<Scalars['String']>;
   fundingRoundFactory_starts_with: Maybe<Scalars['String']>;
+  fundingRoundFactory_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRoundFactory_not_starts_with: Maybe<Scalars['String']>;
+  fundingRoundFactory_not_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRoundFactory_ends_with: Maybe<Scalars['String']>;
+  fundingRoundFactory_ends_with_nocase: Maybe<Scalars['String']>;
   fundingRoundFactory_not_ends_with: Maybe<Scalars['String']>;
+  fundingRoundFactory_not_ends_with_nocase: Maybe<Scalars['String']>;
   maci: Maybe<Scalars['Bytes']>;
   maci_not: Maybe<Scalars['Bytes']>;
   maci_in: Maybe<Array<Scalars['Bytes']>>;
@@ -917,11 +1079,17 @@ export type FundingRound_Filter = {
   recipientRegistry_in: Maybe<Array<Scalars['String']>>;
   recipientRegistry_not_in: Maybe<Array<Scalars['String']>>;
   recipientRegistry_contains: Maybe<Scalars['String']>;
+  recipientRegistry_contains_nocase: Maybe<Scalars['String']>;
   recipientRegistry_not_contains: Maybe<Scalars['String']>;
+  recipientRegistry_not_contains_nocase: Maybe<Scalars['String']>;
   recipientRegistry_starts_with: Maybe<Scalars['String']>;
+  recipientRegistry_starts_with_nocase: Maybe<Scalars['String']>;
   recipientRegistry_not_starts_with: Maybe<Scalars['String']>;
+  recipientRegistry_not_starts_with_nocase: Maybe<Scalars['String']>;
   recipientRegistry_ends_with: Maybe<Scalars['String']>;
+  recipientRegistry_ends_with_nocase: Maybe<Scalars['String']>;
   recipientRegistry_not_ends_with: Maybe<Scalars['String']>;
+  recipientRegistry_not_ends_with_nocase: Maybe<Scalars['String']>;
   recipientRegistryAddress: Maybe<Scalars['Bytes']>;
   recipientRegistryAddress_not: Maybe<Scalars['Bytes']>;
   recipientRegistryAddress_in: Maybe<Array<Scalars['Bytes']>>;
@@ -937,11 +1105,17 @@ export type FundingRound_Filter = {
   contributorRegistry_in: Maybe<Array<Scalars['String']>>;
   contributorRegistry_not_in: Maybe<Array<Scalars['String']>>;
   contributorRegistry_contains: Maybe<Scalars['String']>;
+  contributorRegistry_contains_nocase: Maybe<Scalars['String']>;
   contributorRegistry_not_contains: Maybe<Scalars['String']>;
+  contributorRegistry_not_contains_nocase: Maybe<Scalars['String']>;
   contributorRegistry_starts_with: Maybe<Scalars['String']>;
+  contributorRegistry_starts_with_nocase: Maybe<Scalars['String']>;
   contributorRegistry_not_starts_with: Maybe<Scalars['String']>;
+  contributorRegistry_not_starts_with_nocase: Maybe<Scalars['String']>;
   contributorRegistry_ends_with: Maybe<Scalars['String']>;
+  contributorRegistry_ends_with_nocase: Maybe<Scalars['String']>;
   contributorRegistry_not_ends_with: Maybe<Scalars['String']>;
+  contributorRegistry_not_ends_with_nocase: Maybe<Scalars['String']>;
   contributorRegistryAddress: Maybe<Scalars['Bytes']>;
   contributorRegistryAddress_not: Maybe<Scalars['Bytes']>;
   contributorRegistryAddress_in: Maybe<Array<Scalars['Bytes']>>;
@@ -1049,11 +1223,17 @@ export type FundingRound_Filter = {
   tallyHash_in: Maybe<Array<Scalars['String']>>;
   tallyHash_not_in: Maybe<Array<Scalars['String']>>;
   tallyHash_contains: Maybe<Scalars['String']>;
+  tallyHash_contains_nocase: Maybe<Scalars['String']>;
   tallyHash_not_contains: Maybe<Scalars['String']>;
+  tallyHash_not_contains_nocase: Maybe<Scalars['String']>;
   tallyHash_starts_with: Maybe<Scalars['String']>;
+  tallyHash_starts_with_nocase: Maybe<Scalars['String']>;
   tallyHash_not_starts_with: Maybe<Scalars['String']>;
+  tallyHash_not_starts_with_nocase: Maybe<Scalars['String']>;
   tallyHash_ends_with: Maybe<Scalars['String']>;
+  tallyHash_ends_with_nocase: Maybe<Scalars['String']>;
   tallyHash_not_ends_with: Maybe<Scalars['String']>;
+  tallyHash_not_ends_with_nocase: Maybe<Scalars['String']>;
   createdAt: Maybe<Scalars['String']>;
   createdAt_not: Maybe<Scalars['String']>;
   createdAt_gt: Maybe<Scalars['String']>;
@@ -1063,11 +1243,17 @@ export type FundingRound_Filter = {
   createdAt_in: Maybe<Array<Scalars['String']>>;
   createdAt_not_in: Maybe<Array<Scalars['String']>>;
   createdAt_contains: Maybe<Scalars['String']>;
+  createdAt_contains_nocase: Maybe<Scalars['String']>;
   createdAt_not_contains: Maybe<Scalars['String']>;
+  createdAt_not_contains_nocase: Maybe<Scalars['String']>;
   createdAt_starts_with: Maybe<Scalars['String']>;
+  createdAt_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_starts_with: Maybe<Scalars['String']>;
+  createdAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_ends_with: Maybe<Scalars['String']>;
+  createdAt_ends_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_ends_with: Maybe<Scalars['String']>;
+  createdAt_not_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt: Maybe<Scalars['String']>;
   lastUpdatedAt_not: Maybe<Scalars['String']>;
   lastUpdatedAt_gt: Maybe<Scalars['String']>;
@@ -1077,11 +1263,19 @@ export type FundingRound_Filter = {
   lastUpdatedAt_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_not_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_ends_with_nocase: Maybe<Scalars['String']>;
+  /** Filter for the block changed event. */
+  _change_block: Maybe<BlockChangedFilter>;
 };
 
 export enum FundingRound_OrderBy {
@@ -1137,7 +1331,9 @@ export type Message_Filter = {
   data: Maybe<Array<Scalars['BigInt']>>;
   data_not: Maybe<Array<Scalars['BigInt']>>;
   data_contains: Maybe<Array<Scalars['BigInt']>>;
+  data_contains_nocase: Maybe<Array<Scalars['BigInt']>>;
   data_not_contains: Maybe<Array<Scalars['BigInt']>>;
+  data_not_contains_nocase: Maybe<Array<Scalars['BigInt']>>;
   iv: Maybe<Scalars['BigInt']>;
   iv_not: Maybe<Scalars['BigInt']>;
   iv_gt: Maybe<Scalars['BigInt']>;
@@ -1155,11 +1351,17 @@ export type Message_Filter = {
   publicKey_in: Maybe<Array<Scalars['String']>>;
   publicKey_not_in: Maybe<Array<Scalars['String']>>;
   publicKey_contains: Maybe<Scalars['String']>;
+  publicKey_contains_nocase: Maybe<Scalars['String']>;
   publicKey_not_contains: Maybe<Scalars['String']>;
+  publicKey_not_contains_nocase: Maybe<Scalars['String']>;
   publicKey_starts_with: Maybe<Scalars['String']>;
+  publicKey_starts_with_nocase: Maybe<Scalars['String']>;
   publicKey_not_starts_with: Maybe<Scalars['String']>;
+  publicKey_not_starts_with_nocase: Maybe<Scalars['String']>;
   publicKey_ends_with: Maybe<Scalars['String']>;
+  publicKey_ends_with_nocase: Maybe<Scalars['String']>;
   publicKey_not_ends_with: Maybe<Scalars['String']>;
+  publicKey_not_ends_with_nocase: Maybe<Scalars['String']>;
   fundingRound: Maybe<Scalars['String']>;
   fundingRound_not: Maybe<Scalars['String']>;
   fundingRound_gt: Maybe<Scalars['String']>;
@@ -1169,11 +1371,17 @@ export type Message_Filter = {
   fundingRound_in: Maybe<Array<Scalars['String']>>;
   fundingRound_not_in: Maybe<Array<Scalars['String']>>;
   fundingRound_contains: Maybe<Scalars['String']>;
+  fundingRound_contains_nocase: Maybe<Scalars['String']>;
   fundingRound_not_contains: Maybe<Scalars['String']>;
+  fundingRound_not_contains_nocase: Maybe<Scalars['String']>;
   fundingRound_starts_with: Maybe<Scalars['String']>;
+  fundingRound_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRound_not_starts_with: Maybe<Scalars['String']>;
+  fundingRound_not_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRound_ends_with: Maybe<Scalars['String']>;
+  fundingRound_ends_with_nocase: Maybe<Scalars['String']>;
   fundingRound_not_ends_with: Maybe<Scalars['String']>;
+  fundingRound_not_ends_with_nocase: Maybe<Scalars['String']>;
   timestamp: Maybe<Scalars['String']>;
   timestamp_not: Maybe<Scalars['String']>;
   timestamp_gt: Maybe<Scalars['String']>;
@@ -1183,11 +1391,19 @@ export type Message_Filter = {
   timestamp_in: Maybe<Array<Scalars['String']>>;
   timestamp_not_in: Maybe<Array<Scalars['String']>>;
   timestamp_contains: Maybe<Scalars['String']>;
+  timestamp_contains_nocase: Maybe<Scalars['String']>;
   timestamp_not_contains: Maybe<Scalars['String']>;
+  timestamp_not_contains_nocase: Maybe<Scalars['String']>;
   timestamp_starts_with: Maybe<Scalars['String']>;
+  timestamp_starts_with_nocase: Maybe<Scalars['String']>;
   timestamp_not_starts_with: Maybe<Scalars['String']>;
+  timestamp_not_starts_with_nocase: Maybe<Scalars['String']>;
   timestamp_ends_with: Maybe<Scalars['String']>;
+  timestamp_ends_with_nocase: Maybe<Scalars['String']>;
   timestamp_not_ends_with: Maybe<Scalars['String']>;
+  timestamp_not_ends_with_nocase: Maybe<Scalars['String']>;
+  /** Filter for the block changed event. */
+  _change_block: Maybe<BlockChangedFilter>;
 };
 
 export enum Message_OrderBy {
@@ -1199,6 +1415,7 @@ export enum Message_OrderBy {
   Timestamp = 'timestamp'
 }
 
+/** Defines the order direction, either ascending or descending */
 export enum OrderDirection {
   Asc = 'asc',
   Desc = 'desc'
@@ -1242,11 +1459,17 @@ export type PublicKey_Filter = {
   fundingRound_in: Maybe<Array<Scalars['String']>>;
   fundingRound_not_in: Maybe<Array<Scalars['String']>>;
   fundingRound_contains: Maybe<Scalars['String']>;
+  fundingRound_contains_nocase: Maybe<Scalars['String']>;
   fundingRound_not_contains: Maybe<Scalars['String']>;
+  fundingRound_not_contains_nocase: Maybe<Scalars['String']>;
   fundingRound_starts_with: Maybe<Scalars['String']>;
+  fundingRound_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRound_not_starts_with: Maybe<Scalars['String']>;
+  fundingRound_not_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRound_ends_with: Maybe<Scalars['String']>;
+  fundingRound_ends_with_nocase: Maybe<Scalars['String']>;
   fundingRound_not_ends_with: Maybe<Scalars['String']>;
+  fundingRound_not_ends_with_nocase: Maybe<Scalars['String']>;
   x: Maybe<Scalars['BigInt']>;
   x_not: Maybe<Scalars['BigInt']>;
   x_gt: Maybe<Scalars['BigInt']>;
@@ -1279,6 +1502,8 @@ export type PublicKey_Filter = {
   voiceCreditBalance_lte: Maybe<Scalars['BigInt']>;
   voiceCreditBalance_in: Maybe<Array<Scalars['BigInt']>>;
   voiceCreditBalance_not_in: Maybe<Array<Scalars['BigInt']>>;
+  /** Filter for the block changed event. */
+  _change_block: Maybe<BlockChangedFilter>;
 };
 
 export enum PublicKey_OrderBy {
@@ -1643,11 +1868,17 @@ export type RecipientRegistry_Filter = {
   fundingRoundFactory_in: Maybe<Array<Scalars['String']>>;
   fundingRoundFactory_not_in: Maybe<Array<Scalars['String']>>;
   fundingRoundFactory_contains: Maybe<Scalars['String']>;
+  fundingRoundFactory_contains_nocase: Maybe<Scalars['String']>;
   fundingRoundFactory_not_contains: Maybe<Scalars['String']>;
+  fundingRoundFactory_not_contains_nocase: Maybe<Scalars['String']>;
   fundingRoundFactory_starts_with: Maybe<Scalars['String']>;
+  fundingRoundFactory_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRoundFactory_not_starts_with: Maybe<Scalars['String']>;
+  fundingRoundFactory_not_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRoundFactory_ends_with: Maybe<Scalars['String']>;
+  fundingRoundFactory_ends_with_nocase: Maybe<Scalars['String']>;
   fundingRoundFactory_not_ends_with: Maybe<Scalars['String']>;
+  fundingRoundFactory_not_ends_with_nocase: Maybe<Scalars['String']>;
   baseDeposit: Maybe<Scalars['BigInt']>;
   baseDeposit_not: Maybe<Scalars['BigInt']>;
   baseDeposit_gt: Maybe<Scalars['BigInt']>;
@@ -1693,11 +1924,17 @@ export type RecipientRegistry_Filter = {
   createdAt_in: Maybe<Array<Scalars['String']>>;
   createdAt_not_in: Maybe<Array<Scalars['String']>>;
   createdAt_contains: Maybe<Scalars['String']>;
+  createdAt_contains_nocase: Maybe<Scalars['String']>;
   createdAt_not_contains: Maybe<Scalars['String']>;
+  createdAt_not_contains_nocase: Maybe<Scalars['String']>;
   createdAt_starts_with: Maybe<Scalars['String']>;
+  createdAt_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_starts_with: Maybe<Scalars['String']>;
+  createdAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_ends_with: Maybe<Scalars['String']>;
+  createdAt_ends_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_ends_with: Maybe<Scalars['String']>;
+  createdAt_not_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt: Maybe<Scalars['String']>;
   lastUpdatedAt_not: Maybe<Scalars['String']>;
   lastUpdatedAt_gt: Maybe<Scalars['String']>;
@@ -1707,11 +1944,19 @@ export type RecipientRegistry_Filter = {
   lastUpdatedAt_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_not_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_ends_with_nocase: Maybe<Scalars['String']>;
+  /** Filter for the block changed event. */
+  _change_block: Maybe<BlockChangedFilter>;
 };
 
 export enum RecipientRegistry_OrderBy {
@@ -1745,11 +1990,17 @@ export type Recipient_Filter = {
   recipientRegistry_in: Maybe<Array<Scalars['String']>>;
   recipientRegistry_not_in: Maybe<Array<Scalars['String']>>;
   recipientRegistry_contains: Maybe<Scalars['String']>;
+  recipientRegistry_contains_nocase: Maybe<Scalars['String']>;
   recipientRegistry_not_contains: Maybe<Scalars['String']>;
+  recipientRegistry_not_contains_nocase: Maybe<Scalars['String']>;
   recipientRegistry_starts_with: Maybe<Scalars['String']>;
+  recipientRegistry_starts_with_nocase: Maybe<Scalars['String']>;
   recipientRegistry_not_starts_with: Maybe<Scalars['String']>;
+  recipientRegistry_not_starts_with_nocase: Maybe<Scalars['String']>;
   recipientRegistry_ends_with: Maybe<Scalars['String']>;
+  recipientRegistry_ends_with_nocase: Maybe<Scalars['String']>;
   recipientRegistry_not_ends_with: Maybe<Scalars['String']>;
+  recipientRegistry_not_ends_with_nocase: Maybe<Scalars['String']>;
   recipientIndex: Maybe<Scalars['BigInt']>;
   recipientIndex_not: Maybe<Scalars['BigInt']>;
   recipientIndex_gt: Maybe<Scalars['BigInt']>;
@@ -1767,11 +2018,17 @@ export type Recipient_Filter = {
   requestType_in: Maybe<Array<Scalars['String']>>;
   requestType_not_in: Maybe<Array<Scalars['String']>>;
   requestType_contains: Maybe<Scalars['String']>;
+  requestType_contains_nocase: Maybe<Scalars['String']>;
   requestType_not_contains: Maybe<Scalars['String']>;
+  requestType_not_contains_nocase: Maybe<Scalars['String']>;
   requestType_starts_with: Maybe<Scalars['String']>;
+  requestType_starts_with_nocase: Maybe<Scalars['String']>;
   requestType_not_starts_with: Maybe<Scalars['String']>;
+  requestType_not_starts_with_nocase: Maybe<Scalars['String']>;
   requestType_ends_with: Maybe<Scalars['String']>;
+  requestType_ends_with_nocase: Maybe<Scalars['String']>;
   requestType_not_ends_with: Maybe<Scalars['String']>;
+  requestType_not_ends_with_nocase: Maybe<Scalars['String']>;
   requester: Maybe<Scalars['String']>;
   requester_not: Maybe<Scalars['String']>;
   requester_gt: Maybe<Scalars['String']>;
@@ -1781,11 +2038,17 @@ export type Recipient_Filter = {
   requester_in: Maybe<Array<Scalars['String']>>;
   requester_not_in: Maybe<Array<Scalars['String']>>;
   requester_contains: Maybe<Scalars['String']>;
+  requester_contains_nocase: Maybe<Scalars['String']>;
   requester_not_contains: Maybe<Scalars['String']>;
+  requester_not_contains_nocase: Maybe<Scalars['String']>;
   requester_starts_with: Maybe<Scalars['String']>;
+  requester_starts_with_nocase: Maybe<Scalars['String']>;
   requester_not_starts_with: Maybe<Scalars['String']>;
+  requester_not_starts_with_nocase: Maybe<Scalars['String']>;
   requester_ends_with: Maybe<Scalars['String']>;
+  requester_ends_with_nocase: Maybe<Scalars['String']>;
   requester_not_ends_with: Maybe<Scalars['String']>;
+  requester_not_ends_with_nocase: Maybe<Scalars['String']>;
   submissionTime: Maybe<Scalars['String']>;
   submissionTime_not: Maybe<Scalars['String']>;
   submissionTime_gt: Maybe<Scalars['String']>;
@@ -1795,11 +2058,17 @@ export type Recipient_Filter = {
   submissionTime_in: Maybe<Array<Scalars['String']>>;
   submissionTime_not_in: Maybe<Array<Scalars['String']>>;
   submissionTime_contains: Maybe<Scalars['String']>;
+  submissionTime_contains_nocase: Maybe<Scalars['String']>;
   submissionTime_not_contains: Maybe<Scalars['String']>;
+  submissionTime_not_contains_nocase: Maybe<Scalars['String']>;
   submissionTime_starts_with: Maybe<Scalars['String']>;
+  submissionTime_starts_with_nocase: Maybe<Scalars['String']>;
   submissionTime_not_starts_with: Maybe<Scalars['String']>;
+  submissionTime_not_starts_with_nocase: Maybe<Scalars['String']>;
   submissionTime_ends_with: Maybe<Scalars['String']>;
+  submissionTime_ends_with_nocase: Maybe<Scalars['String']>;
   submissionTime_not_ends_with: Maybe<Scalars['String']>;
+  submissionTime_not_ends_with_nocase: Maybe<Scalars['String']>;
   deposit: Maybe<Scalars['BigInt']>;
   deposit_not: Maybe<Scalars['BigInt']>;
   deposit_gt: Maybe<Scalars['BigInt']>;
@@ -1823,11 +2092,17 @@ export type Recipient_Filter = {
   recipientMetadata_in: Maybe<Array<Scalars['String']>>;
   recipientMetadata_not_in: Maybe<Array<Scalars['String']>>;
   recipientMetadata_contains: Maybe<Scalars['String']>;
+  recipientMetadata_contains_nocase: Maybe<Scalars['String']>;
   recipientMetadata_not_contains: Maybe<Scalars['String']>;
+  recipientMetadata_not_contains_nocase: Maybe<Scalars['String']>;
   recipientMetadata_starts_with: Maybe<Scalars['String']>;
+  recipientMetadata_starts_with_nocase: Maybe<Scalars['String']>;
   recipientMetadata_not_starts_with: Maybe<Scalars['String']>;
+  recipientMetadata_not_starts_with_nocase: Maybe<Scalars['String']>;
   recipientMetadata_ends_with: Maybe<Scalars['String']>;
+  recipientMetadata_ends_with_nocase: Maybe<Scalars['String']>;
   recipientMetadata_not_ends_with: Maybe<Scalars['String']>;
+  recipientMetadata_not_ends_with_nocase: Maybe<Scalars['String']>;
   rejected: Maybe<Scalars['Boolean']>;
   rejected_not: Maybe<Scalars['Boolean']>;
   rejected_in: Maybe<Array<Scalars['Boolean']>>;
@@ -1859,7 +2134,9 @@ export type Recipient_Filter = {
   fundingRounds: Maybe<Array<Scalars['String']>>;
   fundingRounds_not: Maybe<Array<Scalars['String']>>;
   fundingRounds_contains: Maybe<Array<Scalars['String']>>;
+  fundingRounds_contains_nocase: Maybe<Array<Scalars['String']>>;
   fundingRounds_not_contains: Maybe<Array<Scalars['String']>>;
+  fundingRounds_not_contains_nocase: Maybe<Array<Scalars['String']>>;
   createdAt: Maybe<Scalars['String']>;
   createdAt_not: Maybe<Scalars['String']>;
   createdAt_gt: Maybe<Scalars['String']>;
@@ -1869,11 +2146,17 @@ export type Recipient_Filter = {
   createdAt_in: Maybe<Array<Scalars['String']>>;
   createdAt_not_in: Maybe<Array<Scalars['String']>>;
   createdAt_contains: Maybe<Scalars['String']>;
+  createdAt_contains_nocase: Maybe<Scalars['String']>;
   createdAt_not_contains: Maybe<Scalars['String']>;
+  createdAt_not_contains_nocase: Maybe<Scalars['String']>;
   createdAt_starts_with: Maybe<Scalars['String']>;
+  createdAt_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_starts_with: Maybe<Scalars['String']>;
+  createdAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_ends_with: Maybe<Scalars['String']>;
+  createdAt_ends_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_ends_with: Maybe<Scalars['String']>;
+  createdAt_not_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt: Maybe<Scalars['String']>;
   lastUpdatedAt_not: Maybe<Scalars['String']>;
   lastUpdatedAt_gt: Maybe<Scalars['String']>;
@@ -1883,11 +2166,19 @@ export type Recipient_Filter = {
   lastUpdatedAt_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_not_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_ends_with_nocase: Maybe<Scalars['String']>;
+  /** Filter for the block changed event. */
+  _change_block: Maybe<BlockChangedFilter>;
 };
 
 export enum Recipient_OrderBy {
@@ -2216,11 +2507,17 @@ export type Token_Filter = {
   symbol_in: Maybe<Array<Scalars['String']>>;
   symbol_not_in: Maybe<Array<Scalars['String']>>;
   symbol_contains: Maybe<Scalars['String']>;
+  symbol_contains_nocase: Maybe<Scalars['String']>;
   symbol_not_contains: Maybe<Scalars['String']>;
+  symbol_not_contains_nocase: Maybe<Scalars['String']>;
   symbol_starts_with: Maybe<Scalars['String']>;
+  symbol_starts_with_nocase: Maybe<Scalars['String']>;
   symbol_not_starts_with: Maybe<Scalars['String']>;
+  symbol_not_starts_with_nocase: Maybe<Scalars['String']>;
   symbol_ends_with: Maybe<Scalars['String']>;
+  symbol_ends_with_nocase: Maybe<Scalars['String']>;
   symbol_not_ends_with: Maybe<Scalars['String']>;
+  symbol_not_ends_with_nocase: Maybe<Scalars['String']>;
   decimals: Maybe<Scalars['BigInt']>;
   decimals_not: Maybe<Scalars['BigInt']>;
   decimals_gt: Maybe<Scalars['BigInt']>;
@@ -2238,11 +2535,17 @@ export type Token_Filter = {
   createdAt_in: Maybe<Array<Scalars['String']>>;
   createdAt_not_in: Maybe<Array<Scalars['String']>>;
   createdAt_contains: Maybe<Scalars['String']>;
+  createdAt_contains_nocase: Maybe<Scalars['String']>;
   createdAt_not_contains: Maybe<Scalars['String']>;
+  createdAt_not_contains_nocase: Maybe<Scalars['String']>;
   createdAt_starts_with: Maybe<Scalars['String']>;
+  createdAt_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_starts_with: Maybe<Scalars['String']>;
+  createdAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   createdAt_ends_with: Maybe<Scalars['String']>;
+  createdAt_ends_with_nocase: Maybe<Scalars['String']>;
   createdAt_not_ends_with: Maybe<Scalars['String']>;
+  createdAt_not_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt: Maybe<Scalars['String']>;
   lastUpdatedAt_not: Maybe<Scalars['String']>;
   lastUpdatedAt_gt: Maybe<Scalars['String']>;
@@ -2252,11 +2555,19 @@ export type Token_Filter = {
   lastUpdatedAt_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_not_in: Maybe<Array<Scalars['String']>>;
   lastUpdatedAt_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_contains: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_contains_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_starts_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_starts_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_ends_with_nocase: Maybe<Scalars['String']>;
   lastUpdatedAt_not_ends_with: Maybe<Scalars['String']>;
+  lastUpdatedAt_not_ends_with_nocase: Maybe<Scalars['String']>;
+  /** Filter for the block changed event. */
+  _change_block: Maybe<BlockChangedFilter>;
 };
 
 export enum Token_OrderBy {
@@ -2295,11 +2606,17 @@ export type Vote_Filter = {
   contributor_in: Maybe<Array<Scalars['String']>>;
   contributor_not_in: Maybe<Array<Scalars['String']>>;
   contributor_contains: Maybe<Scalars['String']>;
+  contributor_contains_nocase: Maybe<Scalars['String']>;
   contributor_not_contains: Maybe<Scalars['String']>;
+  contributor_not_contains_nocase: Maybe<Scalars['String']>;
   contributor_starts_with: Maybe<Scalars['String']>;
+  contributor_starts_with_nocase: Maybe<Scalars['String']>;
   contributor_not_starts_with: Maybe<Scalars['String']>;
+  contributor_not_starts_with_nocase: Maybe<Scalars['String']>;
   contributor_ends_with: Maybe<Scalars['String']>;
+  contributor_ends_with_nocase: Maybe<Scalars['String']>;
   contributor_not_ends_with: Maybe<Scalars['String']>;
+  contributor_not_ends_with_nocase: Maybe<Scalars['String']>;
   fundingRound: Maybe<Scalars['String']>;
   fundingRound_not: Maybe<Scalars['String']>;
   fundingRound_gt: Maybe<Scalars['String']>;
@@ -2309,11 +2626,17 @@ export type Vote_Filter = {
   fundingRound_in: Maybe<Array<Scalars['String']>>;
   fundingRound_not_in: Maybe<Array<Scalars['String']>>;
   fundingRound_contains: Maybe<Scalars['String']>;
+  fundingRound_contains_nocase: Maybe<Scalars['String']>;
   fundingRound_not_contains: Maybe<Scalars['String']>;
+  fundingRound_not_contains_nocase: Maybe<Scalars['String']>;
   fundingRound_starts_with: Maybe<Scalars['String']>;
+  fundingRound_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRound_not_starts_with: Maybe<Scalars['String']>;
+  fundingRound_not_starts_with_nocase: Maybe<Scalars['String']>;
   fundingRound_ends_with: Maybe<Scalars['String']>;
+  fundingRound_ends_with_nocase: Maybe<Scalars['String']>;
   fundingRound_not_ends_with: Maybe<Scalars['String']>;
+  fundingRound_not_ends_with_nocase: Maybe<Scalars['String']>;
   voterAddress: Maybe<Scalars['Bytes']>;
   voterAddress_not: Maybe<Scalars['Bytes']>;
   voterAddress_in: Maybe<Array<Scalars['Bytes']>>;
@@ -2324,6 +2647,8 @@ export type Vote_Filter = {
   secret_not: Maybe<Scalars['Boolean']>;
   secret_in: Maybe<Array<Scalars['Boolean']>>;
   secret_not_in: Maybe<Array<Scalars['Boolean']>>;
+  /** Filter for the block changed event. */
+  _change_block: Maybe<BlockChangedFilter>;
 };
 
 export enum Vote_OrderBy {
@@ -2422,7 +2747,7 @@ export type GetTotalContributedQueryVariables = Exact<{
 }>;
 
 
-export type GetTotalContributedQuery = { __typename?: 'Query', fundingRound: Maybe<{ __typename?: 'FundingRound', contributorCount: any, contributors: Maybe<Array<{ __typename?: 'Contributor', contributions: Maybe<Array<{ __typename?: 'Contribution', amount: Maybe<any> }>> }>> }> };
+export type GetTotalContributedQuery = { __typename?: 'Query', fundingRound: Maybe<{ __typename?: 'FundingRound', contributorCount: any }> };
 
 
 export const GetContributionsAmountDocument = gql`
@@ -2514,11 +2839,6 @@ export const GetTotalContributedDocument = gql`
     query GetTotalContributed($fundingRoundAddress: ID!) {
   fundingRound(id: $fundingRoundAddress) {
     contributorCount
-    contributors {
-      contributions {
-        amount
-      }
-    }
   }
 }
     `;

--- a/vue-app/src/graphql/queries/GetTotalContributed.graphql
+++ b/vue-app/src/graphql/queries/GetTotalContributed.graphql
@@ -1,10 +1,5 @@
 query GetTotalContributed($fundingRoundAddress: ID!) {
   fundingRound(id: $fundingRoundAddress) {
     contributorCount
-    contributors {
-      contributions {
-        amount
-      }
-    }
   }
 }


### PR DESCRIPTION
We were fetching each individual contribution from thegraph endpoint (~1800 contributions so far).

Seems that thegraph has understandable limits on the amount of data they return (100 items).

This PR fetches the balance from the contract directly instead of thegraph endpoint.