### PR TITLE
Hide the add project callout on landing page if passed deadline

### DIFF
--- a/vue-app/src/store/getters.ts
+++ b/vue-app/src/store/getters.ts
@@ -49,17 +49,13 @@ const getters = {
         ? state.recipientRegistryInfo.challengePeriodDuration
         : 0
 
-    return state.currentRound.signUpDeadline.minus({
+    const deadline = state.currentRound.signUpDeadline.minus({
       seconds: challengePeriodDuration,
     })
+
+    return deadline.isValid ? deadline : null
   },
   isRoundJoinPhase: (state: RootState, getters): boolean => {
-    if (!state.currentRound) {
-      return true
-    }
-    if (!state.recipientRegistryInfo) {
-      return false
-    }
     return !hasDateElapsed(getters.recipientJoinDeadline)
   },
   isRoundJoinOnlyPhase: (state: RootState, getters): boolean => {


### PR DESCRIPTION
Instead of showing 0 days 0 hour to join the funding round on the landing page, this PR will hide the callout. The issue was the challenge period is set too large causing an invalid date.