### PR TITLE
Disable navigation buttons while waiting for transaction to be submitted

### DIFF
--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -941,6 +941,10 @@ export default class JoinView extends mixins(validationMixin) {
   }
 
   isStepValid(step: number): boolean {
+    if (this.isWaiting) {
+      return !this.isWaiting
+    }
+
     if (step === 3) {
       return this.isLinkStepValid()
     }


### PR DESCRIPTION
This PR disables navigation buttons during the submission of recipient data.  This is to prevent the user from clicking the submit button while the transaction is being processed.

