### PR TITLE
Upload ipfs file using pinata

### DIFF
--- a/vue-app/.env.example
+++ b/vue-app/.env.example
@@ -6,6 +6,11 @@ VUE_APP_ETHEREUM_API_URL=http://localhost:18545
 VUE_APP_ETHEREUM_API_CHAINID=31337
 VUE_APP_INFURA_ID=
 VUE_APP_IPFS_GATEWAY_URL=https://ipfs.io
+
+# ipfs file upload and pinning url
+VUE_APP_IPFS_PINNING_URL=https://api.pinata.cloud/pinning/pinFileToIPFS
+# pinata api JWT for api authorization
+VUE_APP_IPFS_PINNING_JWT=
 VUE_APP_SUBGRAPH_URL=http://localhost:8000/subgraphs/name/daodesigner/clrfund
 
 # Comma-separated list of URLs

--- a/vue-app/src/api/core.ts
+++ b/vue-app/src/api/core.ts
@@ -17,6 +17,11 @@ export const gunPeers: string[] = process.env.VUE_APP_GUN_PEERS
   ? process.env.VUE_APP_GUN_PEERS.split(',')
   : []
 
+export const ipfsPinningUrl = process.env.VUE_APP_IPFS_PINNING_URL
+if (!ipfsPinningUrl) throw new Error('invalid ipfs pinning url')
+export const ipfsPinningJwt = process.env.VUE_APP_IPFS_PINNING_JWT
+if (!ipfsPinningJwt) throw new Error('invalid ipfs pinning JWT')
+
 //TODO: need to be able to pass the factory contract address dynamically, note all places this is used make factory address a parameter that defaults to the env. variable set
 //NOTE: these calls will be replaced by subgraph queries eventually.
 export const factory = new ethers.Contract(

--- a/vue-app/src/api/ipfs.ts
+++ b/vue-app/src/api/ipfs.ts
@@ -1,0 +1,28 @@
+import { ipfsPinningUrl, ipfsPinningJwt } from './core'
+
+export class IPFS {
+  url: string
+  jwt: string
+
+  constructor() {
+    this.url = ipfsPinningUrl || ''
+    this.jwt = ipfsPinningJwt || ''
+  }
+
+  async add(file: File): Promise<string> {
+    const data = new FormData()
+    data.append('file', file)
+
+    const options = {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.jwt}`,
+      },
+      body: data,
+    }
+
+    const result = await fetch(this.url, options)
+    const json = await result.json()
+    return json.IpfsHash
+  }
+}

--- a/vue-app/src/components/IpfsImageUpload.vue
+++ b/vue-app/src/components/IpfsImageUpload.vue
@@ -20,7 +20,7 @@
         type="submit"
         label="Upload"
         class="btn-primary"
-        :disabled="loading || error || !loadedImageData"
+        :disabled="loading || error || !loadedImageFile"
       >
         {{ loading ? 'Uploading...' : 'Upload' }}
       </button>
@@ -68,7 +68,7 @@ import { ipfsGatewayUrl } from '@/api/core'
 import Loader from '@/components/Loader.vue'
 import IpfsCopyWidget from '@/components/IpfsCopyWidget.vue'
 
-import IPFS from 'ipfs-mini'
+import { IPFS } from '@/api/ipfs'
 
 @Component({
   components: {
@@ -82,20 +82,16 @@ export default class IpfsImageUpload extends Vue {
   @Prop() formProp!: string
   @Prop() onUpload!: (key: string, value: string) => void
 
-  ipfs: any = null
+  ipfs: IPFS | null = null
   hash = ''
   loading = false
-  loadedImageData = ''
+  loadedImageFile: File | null = null
   loadedImageHeight: number | null = null
   loadedImageWidth: number | null = null
   error = ''
 
   created() {
-    this.ipfs = new IPFS({
-      host: 'ipfs.infura.io',
-      port: 5001,
-      protocol: 'https',
-    })
+    this.ipfs = new IPFS()
   }
 
   // TODO raise error if not valid image (JPG / PNG / GIF)
@@ -113,11 +109,11 @@ export default class IpfsImageUpload extends Vue {
       this.error = 'Upload an image smaller than 512 kB'
       return
     }
+    this.loadedImageFile = data
     const reader = new FileReader()
     reader.onload = (() => (e) => {
-      this.loadedImageData = e.target.result
       const img = new Image()
-      img.src = this.loadedImageData
+      img.src = String(e.target?.result)
       img.onload = () => {
         this.loadedImageHeight = img.height
         this.loadedImageWidth = img.width
@@ -129,21 +125,19 @@ export default class IpfsImageUpload extends Vue {
   // TODO display error in UI
   handleUploadToIPFS(event) {
     event.preventDefault()
-    // Work-around: Raw image data can be loaded through an SVG
-    // https://github.com/SilentCicero/ipfs-mini/issues/4#issuecomment-792351498
-    const fileContents = `<svg x="0" y="0" width="${this.loadedImageWidth}" height="${this.loadedImageHeight}" viewBox="0 0 ${this.loadedImageWidth} ${this.loadedImageHeight}" xmlns="http://www.w3.org/2000/svg"><image href="${this.loadedImageData}" /></svg>`
     if (
-      this.loadedImageData !== '' &&
+      this.ipfs &&
+      this.loadedImageFile &&
       this.loadedImageHeight &&
       this.loadedImageWidth
     ) {
       this.loading = true
       this.ipfs
-        .add(fileContents)
+        .add(this.loadedImageFile)
         .then((hash) => {
           this.hash = hash
           /* eslint-disable-next-line no-console */
-          console.log(`Uploaded file hash: ${hash}`)
+          console.log(`Uploaded file hash:`, hash)
           this.onUpload(this.formProp, hash)
           this.loading = false
         })
@@ -159,8 +153,8 @@ export default class IpfsImageUpload extends Vue {
   handleRemoveImage(): void {
     this.hash = ''
     this.loading = false
-    this.loadedImageData = ''
     this.error = ''
+    this.loadedImageFile = null
     this.onUpload(this.formProp, '')
 
     // Clear file selector input


### PR DESCRIPTION
This PR fixes the image upload error when adding a project.

Infura started to enforce api key for using their IPFS upload api. Since the existing ipfs-mini library does not have the option to pass the api key, I changed the code to use piñata which doesn't require credit card to obtain the api key for development.