### PR TITLE
Simplify BrightId sponsor contract deployment

### DIFF
--- a/contracts/.env.example
+++ b/contracts/.env.example
@@ -8,11 +8,8 @@ BRIGHTID_CONTEXT=clr.fund
 # BrightId node addr that signs verifications. Node One uses this one
 BRIGHTID_VERIFIER_ADDR=0xb1d71F62bEe34E9Fc349234C201090c33BCdF6DB
 
-# used in the BrightId sponsor deployment script
-BRIGHTID_USER_REGISTRY=
-
 # used in the BrightId user registry deployment script
-FUNDING_ROUND_FACTORY_ADDRESS
+FUNDING_ROUND_FACTORY_ADDRESS=
 
 # JSON-RPC endpoint to the selected network
 JSONRPC_HTTP_URL=https://eth-goerli.alchemyapi.io/v2/ADD_API_KEY

--- a/contracts/scripts/deployBrightIdSponsor.ts
+++ b/contracts/scripts/deployBrightIdSponsor.ts
@@ -1,51 +1,21 @@
 import { ethers } from 'hardhat'
-import { Contract, utils } from 'ethers'
 
 async function main() {
-  console.log('*******************')
-  console.log('Deploying a user registry!')
-  console.log('*******************')
-
-  if (!process.env.BRIGHTID_USER_REGISTRY) {
-    console.error('Missing BRIGHTID_USER_REGISTRY environment variable')
-    return
-  }
-  if (!process.env.BRIGHTID_CONTEXT) {
-    console.error('Missing BRIGHTID_CONTEXT environment variable')
-    return
-  }
-  if (!process.env.BRIGHTID_VERIFIER_ADDR) {
-    console.error('Missing BRIGHTID_VERIFIER_ADDR environment variable')
-    return
-  }
+  console.log('**************************************')
+  console.log('Deploying a BrightId sponsor contract!')
+  console.log('**************************************')
 
   const [deployer] = await ethers.getSigners()
-  console.log('deployer.address: ', deployer.address)
+  console.log('Deployer address', deployer.address)
 
-  console.log('deploying brightid sponsor contract')
   const BrightIdSponsor = await ethers.getContractFactory(
     'BrightIdSponsor',
     deployer
   )
   const sponsor = await BrightIdSponsor.deploy()
-  const receipt = await sponsor.deployTransaction.wait()
-  console.log(`Deployed BrightId Sponsor Contract at ${sponsor.address}`)
-  console.log('transaction hash', receipt.transactionHash)
-
-  const userRegistry = await ethers.getContractAt(
-    'BrightIdUserRegistry',
-    process.env.BRIGHTID_USER_REGISTRY
-  )
-  const tx = await userRegistry.setSettings(
-    utils.formatBytes32String(process.env.BRIGHTID_CONTEXT),
-    process.env.BRIGHTID_VERIFIER_ADDR,
-    sponsor.address
-  )
-  const settingReceipt = await tx.wait()
-  console.log(
-    'Set user registry settings at hash',
-    settingReceipt.transactionHash
-  )
+  console.log('Transaction hash', sponsor.deployTransaction.hash)
+  await sponsor.deployTransaction.wait()
+  console.log('Sponsor contract', sponsor.address)
 
   console.log('*******************')
   console.log('Deploy complete!')

--- a/docs/brightid.md
+++ b/docs/brightid.md
@@ -21,8 +21,8 @@ Available envs:
 | Network/Env | Context | Sponsor Contract |
 | ----------- | ------- | ---------------- |
 | goerli | clrfund-goerli | 0xF045234A776C87060DEEc5689056455A24a59c08 |
-| xdai | clrfund-gnosis-chain ||
-| Arbitrum | clrfund-arbitrum ||
+| xdai | clrfund-gnosis-chain |0x669A55Dd17a2f9F4dacC37C7eeB5Ed3e13f474f9|
+| arbitrum | clrfund-arbitrum |0x669A55Dd17a2f9F4dacC37C7eeB5Ed3e13f474f9|
 
 
 ```.sh


### PR DESCRIPTION
Remove the logic to set the sponsor in a BrightId user registry because the user registry may not exist yet.  

The order of contract deployment:
1) deploy BrightId sponsor contract
2) deploy BrightId user registry with the sponsor contract address
3) start a new round
4) set the registration period in the BrightId user registry

