### PR TITLE
Do not check BrightId timestamp

### DIFF
--- a/contracts/scripts/deployRound.ts
+++ b/contracts/scripts/deployRound.ts
@@ -229,18 +229,6 @@ async function main() {
     const maciAddress = await fundingRound.maci()
     console.log('maci.address: ', maciAddress)
 
-    if (userRegistryType === 'brightid') {
-      const maci = await ethers.getContractAt('MACI', maciAddress)
-      const startTime = await maci.signUpTimestamp()
-      const endTime = await maci.calcSignUpDeadline()
-      const periodTx = await userRegistry.setRegistrationPeriod(
-        startTime,
-        endTime
-      )
-      console.log('Set user registration period', periodTx.hash)
-      await periodTx.wait()
-    }
-
     console.log('*******************')
     console.log('Deploy complete!')
     console.log('*******************')

--- a/contracts/scripts/deployTestRound.ts
+++ b/contracts/scripts/deployTestRound.ts
@@ -288,23 +288,6 @@ async function main() {
   const maciAddress = await fundingRound.maci()
   console.log(`MACI address: ${maciAddress}`)
 
-  if (userRegistryType === 'brightid') {
-    const userRegistryAddress = await fundingRound.userRegistry()
-    const userRegistry = await ethers.getContractAt(
-      'BrightIdUserRegistry',
-      userRegistryAddress
-    )
-    const maci = await ethers.getContractAt('MACI', maciAddress)
-    const startTime = await maci.signUpTimestamp()
-    const endTime = await maci.calcSignUpDeadline()
-    const periodTx = await userRegistry.setRegistrationPeriod(
-      startTime,
-      endTime
-    )
-    console.log('Set user registration period', periodTx.hash)
-    await periodTx.wait()
-  }
-
   const recipientRegistryType = process.env.RECIPIENT_REGISTRY_TYPE || 'simple'
   const recipientRegistryAddress = await factory.recipientRegistry()
   if (recipientRegistryType === 'simple') {

--- a/contracts/scripts/newRound.ts
+++ b/contracts/scripts/newRound.ts
@@ -1,4 +1,5 @@
-import { ethers } from 'hardhat'
+import { ethers, network } from 'hardhat'
+import { Contract, utils } from 'ethers'
 
 async function main() {
   console.log('*******************')
@@ -7,14 +8,13 @@ async function main() {
   const [deployer] = await ethers.getSigners()
   console.log('deployer.address: ', deployer.address)
 
-  const fundingRoundFactoryAddress = process.env.FUNDING_ROUND_FACTORY_ADDRESS
+  const fundingRoundFactoryAddress = process.env.FACTORY_ADDRESS
   const userRegistryType = process.env.USER_REGISTRY_TYPE
 
   if (!fundingRoundFactoryAddress) {
-    throw new Error(
-      'Environment variable FUNDING_ROUND_FACTORY_ADDRESS is not setup'
-    )
+    throw new Error('Environment variable FACTORY_ADDRESS is not setup')
   }
+
   if (!userRegistryType) {
     throw new Error('Environment variable USER_REGISTRY_TYPE is not setup')
   }
@@ -25,40 +25,43 @@ async function main() {
   )
   console.log('funding round factory address ', factory.address)
 
+  // check if the current round is finalized before starting a new round to avoid revert
+  const currentRoundAddress = await factory.getCurrentRound()
+  const currentRound = await ethers.getContractAt(
+    'FundingRound',
+    currentRoundAddress
+  )
+  const isFinalized = await currentRound.isFinalized()
+  if (!isFinalized) {
+    throw new Error(
+      'Cannot start a new round as the current round is not finalized'
+    )
+  }
+
+  // deploy a new BrightId user registry for each new round
+  if (userRegistryType === 'brightid') {
+    const BrightIdUserRegistry = await ethers.getContractFactory(
+      'BrightIdUserRegistry',
+      deployer
+    )
+    const userRegistry = await BrightIdUserRegistry.deploy(
+      utils.formatBytes32String(process.env.BRIGHTID_CONTEXT || 'clr.fund'),
+      process.env.BRIGHTID_VERIFIER_ADDR,
+      process.env.BRIGHTID_SPONSOR
+    )
+    console.log('BrightId user registry address: ', userRegistry.address)
+    await userRegistry.deployTransaction.wait()
+
+    const setUserRegistryTx = await factory.setUserRegistry(
+      userRegistry.address
+    )
+    await setUserRegistryTx.wait()
+    console.log('Set user registry in factory', setUserRegistryTx.hash)
+  }
+
   const tx = await factory.deployNewRound()
   console.log('deployNewRound tx hash: ', tx.hash)
   await tx.wait()
-
-  const fundingRoundAddress = await factory.getCurrentRound()
-  console.log('new funding round address: ', fundingRoundAddress)
-
-  // for BrightId user registry, we need to activate the registry
-  // by setting the registration period to match maci signup period
-  if (userRegistryType === 'brightid') {
-    // get maci signup period
-    const fundingRound = await ethers.getContractAt(
-      'FundingRound',
-      fundingRoundAddress
-    )
-    const maciAddress = await fundingRound.maci()
-    console.log('maci address: ', maciAddress)
-    const maci = await ethers.getContractAt('MACI', maciAddress)
-    const startTime = await maci.signUpTimestamp()
-    const endTime = await maci.calcSignUpDeadline()
-
-    // set user registration period
-    const userRegistryAddress = await fundingRound.userRegistry()
-    const userRegistry = await ethers.getContractAt(
-      'BrightIdUserRegistry',
-      userRegistryAddress
-    )
-    const periodTx = await userRegistry.setRegistrationPeriod(
-      startTime,
-      endTime
-    )
-    console.log('User registration period changed at', periodTx.hash)
-    await periodTx.wait()
-  }
 
   console.log('*******************')
   console.log('Script complete!')

--- a/contracts/scripts/newRound.ts
+++ b/contracts/scripts/newRound.ts
@@ -54,6 +54,7 @@ async function main() {
   }
 
   // deploy a new BrightId user registry for each new round
+  // to force users to link with BrightId every round
   if (userRegistryType === 'brightid') {
     const BrightIdUserRegistry = await ethers.getContractFactory(
       'BrightIdUserRegistry',

--- a/docs/brightid.md
+++ b/docs/brightid.md
@@ -20,10 +20,10 @@ Available envs:
 
 | Network/Env | Context | Sponsor Contract |
 | ----------- | ------- | ---------------- |
-| goerli | clrfund-goerli | 0xF045234A776C87060DEEc5689056455A24a59c08 |
-| xdai | clrfund-gnosis-chain |0x669A55Dd17a2f9F4dacC37C7eeB5Ed3e13f474f9|
 | arbitrum | clrfund-arbitrum |0x669A55Dd17a2f9F4dacC37C7eeB5Ed3e13f474f9|
-
+| arbitrum rinkeby | clrfund-arbitrum-rinkeby | 0xC7c81634Dac2de4E7f2Ba407B638ff003ce4534C |
+| goerli | clrfund-goerli | 0xF045234A776C87060DEEc5689056455A24a59c08 |
+| xdai | clrfund-gnosischain |0x669A55Dd17a2f9F4dacC37C7eeB5Ed3e13f474f9|
 
 ```.sh
 # /vue-app/.env

--- a/subgraph/abis/BrightIdUserRegistry.json
+++ b/subgraph/abis/BrightIdUserRegistry.json
@@ -63,25 +63,6 @@
     "inputs": [
       {
         "indexed": false,
-        "internalType": "uint256",
-        "name": "startTime",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "deadline",
-        "type": "uint256"
-      }
-    ],
-    "name": "RegistrationPeriodChanged",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
         "internalType": "bytes32",
         "name": "context",
         "type": "bytes32"
@@ -117,25 +98,6 @@
         "internalType": "contract BrightIdSponsor",
         "name": "",
         "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "_timestamp",
-        "type": "uint256"
-      }
-    ],
-    "name": "canRegister",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
       }
     ],
     "stateMutability": "view",
@@ -231,51 +193,7 @@
   },
   {
     "inputs": [],
-    "name": "registrationDeadline",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "registrationStartTime",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "renounceOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "_startTime",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_deadline",
-        "type": "uint256"
-      }
-    ],
-    "name": "setRegistrationPeriod",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/subgraph/generated/FundingRoundFactory/BrightIdUserRegistry.ts
+++ b/subgraph/generated/FundingRoundFactory/BrightIdUserRegistry.ts
@@ -54,28 +54,6 @@ export class Registered__Params {
   }
 }
 
-export class RegistrationPeriodChanged extends ethereum.Event {
-  get params(): RegistrationPeriodChanged__Params {
-    return new RegistrationPeriodChanged__Params(this);
-  }
-}
-
-export class RegistrationPeriodChanged__Params {
-  _event: RegistrationPeriodChanged;
-
-  constructor(event: RegistrationPeriodChanged) {
-    this._event = event;
-  }
-
-  get startTime(): BigInt {
-    return this._event.parameters[0].value.toBigInt();
-  }
-
-  get deadline(): BigInt {
-    return this._event.parameters[1].value.toBigInt();
-  }
-}
-
 export class SetBrightIdSettings extends ethereum.Event {
   get params(): SetBrightIdSettings__Params {
     return new SetBrightIdSettings__Params(this);
@@ -144,25 +122,6 @@ export class BrightIdUserRegistry extends ethereum.SmartContract {
     return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
-  canRegister(_timestamp: BigInt): boolean {
-    let result = super.call("canRegister", "canRegister(uint256):(bool)", [
-      ethereum.Value.fromUnsignedBigInt(_timestamp)
-    ]);
-
-    return result[0].toBoolean();
-  }
-
-  try_canRegister(_timestamp: BigInt): ethereum.CallResult<boolean> {
-    let result = super.tryCall("canRegister", "canRegister(uint256):(bool)", [
-      ethereum.Value.fromUnsignedBigInt(_timestamp)
-    ]);
-    if (result.reverted) {
-      return new ethereum.CallResult();
-    }
-    let value = result.value;
-    return ethereum.CallResult.fromValue(value[0].toBoolean());
-  }
-
   context(): Bytes {
     let result = super.call("context", "context():(bytes32)", []);
 
@@ -214,52 +173,6 @@ export class BrightIdUserRegistry extends ethereum.SmartContract {
     }
     let value = result.value;
     return ethereum.CallResult.fromValue(value[0].toAddress());
-  }
-
-  registrationDeadline(): BigInt {
-    let result = super.call(
-      "registrationDeadline",
-      "registrationDeadline():(uint256)",
-      []
-    );
-
-    return result[0].toBigInt();
-  }
-
-  try_registrationDeadline(): ethereum.CallResult<BigInt> {
-    let result = super.tryCall(
-      "registrationDeadline",
-      "registrationDeadline():(uint256)",
-      []
-    );
-    if (result.reverted) {
-      return new ethereum.CallResult();
-    }
-    let value = result.value;
-    return ethereum.CallResult.fromValue(value[0].toBigInt());
-  }
-
-  registrationStartTime(): BigInt {
-    let result = super.call(
-      "registrationStartTime",
-      "registrationStartTime():(uint256)",
-      []
-    );
-
-    return result[0].toBigInt();
-  }
-
-  try_registrationStartTime(): ethereum.CallResult<BigInt> {
-    let result = super.tryCall(
-      "registrationStartTime",
-      "registrationStartTime():(uint256)",
-      []
-    );
-    if (result.reverted) {
-      return new ethereum.CallResult();
-    }
-    let value = result.value;
-    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   verifications(param0: Address): BigInt {
@@ -415,40 +328,6 @@ export class RenounceOwnershipCall__Outputs {
   _call: RenounceOwnershipCall;
 
   constructor(call: RenounceOwnershipCall) {
-    this._call = call;
-  }
-}
-
-export class SetRegistrationPeriodCall extends ethereum.Call {
-  get inputs(): SetRegistrationPeriodCall__Inputs {
-    return new SetRegistrationPeriodCall__Inputs(this);
-  }
-
-  get outputs(): SetRegistrationPeriodCall__Outputs {
-    return new SetRegistrationPeriodCall__Outputs(this);
-  }
-}
-
-export class SetRegistrationPeriodCall__Inputs {
-  _call: SetRegistrationPeriodCall;
-
-  constructor(call: SetRegistrationPeriodCall) {
-    this._call = call;
-  }
-
-  get _startTime(): BigInt {
-    return this._call.inputValues[0].value.toBigInt();
-  }
-
-  get _deadline(): BigInt {
-    return this._call.inputValues[1].value.toBigInt();
-  }
-}
-
-export class SetRegistrationPeriodCall__Outputs {
-  _call: SetRegistrationPeriodCall;
-
-  constructor(call: SetRegistrationPeriodCall) {
     this._call = call;
   }
 }

--- a/subgraph/generated/templates/BrightIdUserRegistry/BrightIdUserRegistry.ts
+++ b/subgraph/generated/templates/BrightIdUserRegistry/BrightIdUserRegistry.ts
@@ -54,28 +54,6 @@ export class Registered__Params {
   }
 }
 
-export class RegistrationPeriodChanged extends ethereum.Event {
-  get params(): RegistrationPeriodChanged__Params {
-    return new RegistrationPeriodChanged__Params(this);
-  }
-}
-
-export class RegistrationPeriodChanged__Params {
-  _event: RegistrationPeriodChanged;
-
-  constructor(event: RegistrationPeriodChanged) {
-    this._event = event;
-  }
-
-  get startTime(): BigInt {
-    return this._event.parameters[0].value.toBigInt();
-  }
-
-  get deadline(): BigInt {
-    return this._event.parameters[1].value.toBigInt();
-  }
-}
-
 export class SetBrightIdSettings extends ethereum.Event {
   get params(): SetBrightIdSettings__Params {
     return new SetBrightIdSettings__Params(this);
@@ -144,25 +122,6 @@ export class BrightIdUserRegistry extends ethereum.SmartContract {
     return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
-  canRegister(_timestamp: BigInt): boolean {
-    let result = super.call("canRegister", "canRegister(uint256):(bool)", [
-      ethereum.Value.fromUnsignedBigInt(_timestamp)
-    ]);
-
-    return result[0].toBoolean();
-  }
-
-  try_canRegister(_timestamp: BigInt): ethereum.CallResult<boolean> {
-    let result = super.tryCall("canRegister", "canRegister(uint256):(bool)", [
-      ethereum.Value.fromUnsignedBigInt(_timestamp)
-    ]);
-    if (result.reverted) {
-      return new ethereum.CallResult();
-    }
-    let value = result.value;
-    return ethereum.CallResult.fromValue(value[0].toBoolean());
-  }
-
   context(): Bytes {
     let result = super.call("context", "context():(bytes32)", []);
 
@@ -214,52 +173,6 @@ export class BrightIdUserRegistry extends ethereum.SmartContract {
     }
     let value = result.value;
     return ethereum.CallResult.fromValue(value[0].toAddress());
-  }
-
-  registrationDeadline(): BigInt {
-    let result = super.call(
-      "registrationDeadline",
-      "registrationDeadline():(uint256)",
-      []
-    );
-
-    return result[0].toBigInt();
-  }
-
-  try_registrationDeadline(): ethereum.CallResult<BigInt> {
-    let result = super.tryCall(
-      "registrationDeadline",
-      "registrationDeadline():(uint256)",
-      []
-    );
-    if (result.reverted) {
-      return new ethereum.CallResult();
-    }
-    let value = result.value;
-    return ethereum.CallResult.fromValue(value[0].toBigInt());
-  }
-
-  registrationStartTime(): BigInt {
-    let result = super.call(
-      "registrationStartTime",
-      "registrationStartTime():(uint256)",
-      []
-    );
-
-    return result[0].toBigInt();
-  }
-
-  try_registrationStartTime(): ethereum.CallResult<BigInt> {
-    let result = super.tryCall(
-      "registrationStartTime",
-      "registrationStartTime():(uint256)",
-      []
-    );
-    if (result.reverted) {
-      return new ethereum.CallResult();
-    }
-    let value = result.value;
-    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   verifications(param0: Address): BigInt {
@@ -415,40 +328,6 @@ export class RenounceOwnershipCall__Outputs {
   _call: RenounceOwnershipCall;
 
   constructor(call: RenounceOwnershipCall) {
-    this._call = call;
-  }
-}
-
-export class SetRegistrationPeriodCall extends ethereum.Call {
-  get inputs(): SetRegistrationPeriodCall__Inputs {
-    return new SetRegistrationPeriodCall__Inputs(this);
-  }
-
-  get outputs(): SetRegistrationPeriodCall__Outputs {
-    return new SetRegistrationPeriodCall__Outputs(this);
-  }
-}
-
-export class SetRegistrationPeriodCall__Inputs {
-  _call: SetRegistrationPeriodCall;
-
-  constructor(call: SetRegistrationPeriodCall) {
-    this._call = call;
-  }
-
-  get _startTime(): BigInt {
-    return this._call.inputValues[0].value.toBigInt();
-  }
-
-  get _deadline(): BigInt {
-    return this._call.inputValues[1].value.toBigInt();
-  }
-}
-
-export class SetRegistrationPeriodCall__Outputs {
-  _call: SetRegistrationPeriodCall;
-
-  constructor(call: SetRegistrationPeriodCall) {
     this._call = call;
   }
 }

--- a/subgraph/generated/templates/FundingRound/BrightIdUserRegistry.ts
+++ b/subgraph/generated/templates/FundingRound/BrightIdUserRegistry.ts
@@ -54,28 +54,6 @@ export class Registered__Params {
   }
 }
 
-export class RegistrationPeriodChanged extends ethereum.Event {
-  get params(): RegistrationPeriodChanged__Params {
-    return new RegistrationPeriodChanged__Params(this);
-  }
-}
-
-export class RegistrationPeriodChanged__Params {
-  _event: RegistrationPeriodChanged;
-
-  constructor(event: RegistrationPeriodChanged) {
-    this._event = event;
-  }
-
-  get startTime(): BigInt {
-    return this._event.parameters[0].value.toBigInt();
-  }
-
-  get deadline(): BigInt {
-    return this._event.parameters[1].value.toBigInt();
-  }
-}
-
 export class SetBrightIdSettings extends ethereum.Event {
   get params(): SetBrightIdSettings__Params {
     return new SetBrightIdSettings__Params(this);
@@ -144,25 +122,6 @@ export class BrightIdUserRegistry extends ethereum.SmartContract {
     return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
-  canRegister(_timestamp: BigInt): boolean {
-    let result = super.call("canRegister", "canRegister(uint256):(bool)", [
-      ethereum.Value.fromUnsignedBigInt(_timestamp)
-    ]);
-
-    return result[0].toBoolean();
-  }
-
-  try_canRegister(_timestamp: BigInt): ethereum.CallResult<boolean> {
-    let result = super.tryCall("canRegister", "canRegister(uint256):(bool)", [
-      ethereum.Value.fromUnsignedBigInt(_timestamp)
-    ]);
-    if (result.reverted) {
-      return new ethereum.CallResult();
-    }
-    let value = result.value;
-    return ethereum.CallResult.fromValue(value[0].toBoolean());
-  }
-
   context(): Bytes {
     let result = super.call("context", "context():(bytes32)", []);
 
@@ -214,52 +173,6 @@ export class BrightIdUserRegistry extends ethereum.SmartContract {
     }
     let value = result.value;
     return ethereum.CallResult.fromValue(value[0].toAddress());
-  }
-
-  registrationDeadline(): BigInt {
-    let result = super.call(
-      "registrationDeadline",
-      "registrationDeadline():(uint256)",
-      []
-    );
-
-    return result[0].toBigInt();
-  }
-
-  try_registrationDeadline(): ethereum.CallResult<BigInt> {
-    let result = super.tryCall(
-      "registrationDeadline",
-      "registrationDeadline():(uint256)",
-      []
-    );
-    if (result.reverted) {
-      return new ethereum.CallResult();
-    }
-    let value = result.value;
-    return ethereum.CallResult.fromValue(value[0].toBigInt());
-  }
-
-  registrationStartTime(): BigInt {
-    let result = super.call(
-      "registrationStartTime",
-      "registrationStartTime():(uint256)",
-      []
-    );
-
-    return result[0].toBigInt();
-  }
-
-  try_registrationStartTime(): ethereum.CallResult<BigInt> {
-    let result = super.tryCall(
-      "registrationStartTime",
-      "registrationStartTime():(uint256)",
-      []
-    );
-    if (result.reverted) {
-      return new ethereum.CallResult();
-    }
-    let value = result.value;
-    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   verifications(param0: Address): BigInt {
@@ -415,40 +328,6 @@ export class RenounceOwnershipCall__Outputs {
   _call: RenounceOwnershipCall;
 
   constructor(call: RenounceOwnershipCall) {
-    this._call = call;
-  }
-}
-
-export class SetRegistrationPeriodCall extends ethereum.Call {
-  get inputs(): SetRegistrationPeriodCall__Inputs {
-    return new SetRegistrationPeriodCall__Inputs(this);
-  }
-
-  get outputs(): SetRegistrationPeriodCall__Outputs {
-    return new SetRegistrationPeriodCall__Outputs(this);
-  }
-}
-
-export class SetRegistrationPeriodCall__Inputs {
-  _call: SetRegistrationPeriodCall;
-
-  constructor(call: SetRegistrationPeriodCall) {
-    this._call = call;
-  }
-
-  get _startTime(): BigInt {
-    return this._call.inputValues[0].value.toBigInt();
-  }
-
-  get _deadline(): BigInt {
-    return this._call.inputValues[1].value.toBigInt();
-  }
-}
-
-export class SetRegistrationPeriodCall__Outputs {
-  _call: SetRegistrationPeriodCall;
-
-  constructor(call: SetRegistrationPeriodCall) {
     this._call = call;
   }
 }


### PR DESCRIPTION
This PR removes the check that the timestamp received from the BrightID status endpoint falls in the signup period.

We will create a new user registry every round to force users to link with BrightID for every round.