### PR TITLE
Make the finalize script re-runnable and fix out of bound check

### DIFF
--- a/contracts/scripts/finalize.ts
+++ b/contracts/scripts/finalize.ts
@@ -39,12 +39,18 @@ async function main() {
   console.log('Vote option tree depth', voteOptionTreeDepth)
 
   const batchSize = Number(process.env.TALLY_BATCH_SIZE) || 20
+  const startIndex = await fundingRound.totalTallyResults()
+  const total = tally.results.tally.length
   console.log('Adding tally results in batches of', batchSize)
   const addTallyGas = await addTallyResultsBatch(
     fundingRound,
     voteOptionTreeDepth,
     tally,
-    batchSize
+    batchSize,
+    startIndex,
+    (processed) => {
+      console.log(`Processed ${processed} / ${total}`)
+    }
   )
   console.log('Tally results added. Gas used:', addTallyGas.toString())
 

--- a/contracts/scripts/finalize.ts
+++ b/contracts/scripts/finalize.ts
@@ -47,7 +47,7 @@ async function main() {
     voteOptionTreeDepth,
     tally,
     batchSize,
-    startIndex,
+    startIndex.toNumber(),
     (processed) => {
       console.log(`Processed ${processed} / ${total}`)
     }

--- a/contracts/scripts/newRound.ts
+++ b/contracts/scripts/newRound.ts
@@ -76,8 +76,9 @@ async function main() {
   }
 
   const tx = await factory.deployNewRound()
-  console.log('deployNewRound tx hash: ', tx.hash)
+  console.log('Deployed new round, tx hash: ', tx.hash)
   await tx.wait()
+  console.log('New funding round address: ', await factory.getCurrentRound())
 
   console.log('*******************')
   console.log('Script complete!')

--- a/contracts/tests/round.ts
+++ b/contracts/tests/round.ts
@@ -15,6 +15,7 @@ import {
   createMessage,
   addTallyResultsBatch,
   getRecipientClaimData,
+  getRecipientTallyResultsBatch,
 } from '../utils/maci'
 
 use(solidity)
@@ -1327,6 +1328,45 @@ describe('Funding Round', () => {
           5
         )
       ).to.revertedWith('FundingRound: Vote results already verified')
+    })
+  })
+
+  describe('getRecipientTallyResultsBatch', () => {
+    const treeDepth = 5
+    const batchSize = 5
+    const total = smallTallyTestData.results.tally.length
+    for (const startIndex of [0, Math.floor(total / 2)]) {
+      it(`should pass with startIndex ${startIndex}`, () => {
+        const data = getRecipientTallyResultsBatch(
+          startIndex,
+          treeDepth,
+          smallTallyTestData,
+          batchSize
+        )
+        expect(data).to.have.lengthOf(5)
+        expect(data[1]).to.have.lengthOf(5)
+      })
+    }
+    it(`should pass with startIndex ${total - 1}`, () => {
+      const data = getRecipientTallyResultsBatch(
+        total - 1,
+        treeDepth,
+        smallTallyTestData,
+        batchSize
+      )
+      expect(data).to.have.lengthOf(5)
+      expect(data[1]).to.have.lengthOf(1)
+    })
+    it(`should fail with startIndex ${total}`, () => {
+      const startIndex = total
+      expect(() => {
+        getRecipientTallyResultsBatch(
+          startIndex,
+          treeDepth,
+          smallTallyTestData,
+          batchSize
+        )
+      }).to.throw('Recipient index out of bound')
     })
   })
 


### PR DESCRIPTION
This PR will allow the coordinator to re-run the `finalize` script if it failed halfway while adding the tally results to the funding round contract due to the network error, etc.

Also fix the bound check in the getRecipientTallyResultsBatch function which didn't check the correct field.