### PR TITLE
Use pinata api key and secret api key to authenticate

### DIFF
--- a/vue-app/.env.example
+++ b/vue-app/.env.example
@@ -9,8 +9,14 @@ VUE_APP_IPFS_GATEWAY_URL=https://ipfs.io
 
 # ipfs file upload and pinning url
 VUE_APP_IPFS_PINNING_URL=https://api.pinata.cloud/pinning/pinFileToIPFS
-# pinata api JWT for api authorization
+# pinata api JWT for api authorization. This key is only here for backward compatible
+# it will be removed later as its value is too long and causes netlify functions deployment to fail
 VUE_APP_IPFS_PINNING_JWT=
+# pinata api key and secret api key for uploading project images to ipfs
+# The pinata api only need to set these keys or the VUE_APP_IPFS_PINNING_JWT to authenticate
+VUE_APP_IPFS_API_KEY=
+VUE_APP_IPFS_SECRET_API_KEY=
+
 VUE_APP_SUBGRAPH_URL=http://localhost:8000/subgraphs/name/daodesigner/clrfund
 
 # Comma-separated list of URLs

--- a/vue-app/src/App.vue
+++ b/vue-app/src/App.vue
@@ -36,7 +36,6 @@
 import Vue from 'vue'
 import { Component, Watch } from 'vue-property-decorator'
 
-import { getOsColorScheme } from '@/utils/theme'
 import { getCurrentRound } from '@/api/round'
 import { User } from '@/api/user'
 

--- a/vue-app/src/api/core.ts
+++ b/vue-app/src/api/core.ts
@@ -20,7 +20,14 @@ export const gunPeers: string[] = process.env.VUE_APP_GUN_PEERS
 export const ipfsPinningUrl = process.env.VUE_APP_IPFS_PINNING_URL
 if (!ipfsPinningUrl) throw new Error('invalid ipfs pinning url')
 export const ipfsPinningJwt = process.env.VUE_APP_IPFS_PINNING_JWT
-if (!ipfsPinningJwt) throw new Error('invalid ipfs pinning JWT')
+export const ipfsApiKey = process.env.VUE_APP_IPFS_API_KEY
+export const ipfsSecretApiKey = process.env.VUE_APP_IPFS_SECRET_API_KEY
+if (!ipfsPinningJwt && !(ipfsApiKey && ipfsSecretApiKey)) {
+  throw new Error(
+    'Please setup environment variables for ' +
+      'VUE_APP_IPFS_API_KEY and VUE_APP_IPFS_SECRET_API_KEY or VUE_APP_IPFS_PINNING_JWT'
+  )
+}
 
 //TODO: need to be able to pass the factory contract address dynamically, note all places this is used make factory address a parameter that defaults to the env. variable set
 //NOTE: these calls will be replaced by subgraph queries eventually.

--- a/vue-app/src/api/ipfs.ts
+++ b/vue-app/src/api/ipfs.ts
@@ -1,23 +1,44 @@
-import { ipfsPinningUrl, ipfsPinningJwt } from './core'
+import {
+  ipfsPinningUrl,
+  ipfsPinningJwt,
+  ipfsApiKey,
+  ipfsSecretApiKey,
+} from './core'
 
 export class IPFS {
   url: string
   jwt: string
+  apiKey: string
+  secretApiKey: string
 
   constructor() {
     this.url = ipfsPinningUrl || ''
     this.jwt = ipfsPinningJwt || ''
+    this.apiKey = ipfsApiKey || ''
+    this.secretApiKey = ipfsSecretApiKey || ''
   }
 
   async add(file: File): Promise<string> {
     const data = new FormData()
     data.append('file', file)
 
+    const headers: Record<string, string> = {}
+
+    if (this.jwt) {
+      headers['Authorization'] = `Bearer ${this.jwt}`
+    }
+
+    if (this.apiKey) {
+      headers['pinata_api_key'] = this.apiKey
+    }
+
+    if (this.secretApiKey) {
+      headers['pinata_secret_api_key'] = this.secretApiKey
+    }
+
     const options = {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${this.jwt}`,
-      },
+      headers,
       body: data,
     }
 

--- a/vue-app/src/lambda/hello.js
+++ b/vue-app/src/lambda/hello.js
@@ -1,4 +1,4 @@
-exports.handler = async (event, context) => {
+exports.handler = async () => {
   return {
     statusCode: 200,
     body: 'Hello, World',

--- a/vue-app/src/lambda/hello.js
+++ b/vue-app/src/lambda/hello.js
@@ -1,0 +1,6 @@
+exports.handler = async (event, context) => {
+  return {
+    statusCode: 200,
+    body: 'Hello, World',
+  }
+}


### PR DESCRIPTION
This PR adds an alternative way to authenticate with Pinata because the JWT authentication cause issues in deploying netlify functions due to environment variable values over the 4k limit.

