### PR TITLE
Fix BrightId mobile link

### DIFF
--- a/vue-app/src/api/bright-id.ts
+++ b/vue-app/src/api/bright-id.ts
@@ -4,7 +4,8 @@ import { formatBytes32String } from '@ethersproject/strings'
 
 import { BrightIdUserRegistry } from './abi'
 
-const NODE_URL = 'https://app.brightid.org/node/v6'
+const BRIGHTID_APP_URL = 'https://app.brightid.org/'
+const NODE_URL = `${BRIGHTID_APP_URL}/node/v6`
 const CONTEXT = process.env.VUE_APP_BRIGHTID_CONTEXT || 'clr.fund'
 
 export interface BrightId {
@@ -38,8 +39,15 @@ export async function selfSponsor(
   return transaction
 }
 
+// This link is for generating QR code
 export function getBrightIdLink(userAddress: string): string {
   const deepLink = `brightid://link-verification/${CONTEXT}/${userAddress}`
+  return deepLink
+}
+
+// This is for mobile app to launch BrightId app
+export function getBrightIdUnversalLink(userAddress: string): string {
+  const deepLink = `${BRIGHTID_APP_URL}/link-verification/${CONTEXT}/${userAddress}`
   return deepLink
 }
 

--- a/vue-app/src/api/bright-id.ts
+++ b/vue-app/src/api/bright-id.ts
@@ -80,11 +80,9 @@ export async function getSponsorship(
 export async function getVerification(
   userAddress: string
 ): Promise<Verification> {
-  // do not cache result so we get the status change sooner
-  const headers = new Headers()
-  headers.append('cache-control', 'no-store')
   const apiUrl = `${NODE_URL}/verifications/${CONTEXT}/${userAddress}?signed=eth&timestamp=seconds`
-  const response = await fetch(apiUrl, { headers })
+  // bypass the cache so we get the status change sooner
+  const response = await fetch(apiUrl, { cache: 'no-store' })
   const data = await response.json()
 
   if (data['error']) {

--- a/vue-app/src/api/bright-id.ts
+++ b/vue-app/src/api/bright-id.ts
@@ -4,7 +4,7 @@ import { formatBytes32String } from '@ethersproject/strings'
 
 import { BrightIdUserRegistry } from './abi'
 
-const BRIGHTID_APP_URL = 'https://app.brightid.org/'
+const BRIGHTID_APP_URL = 'https://app.brightid.org'
 const NODE_URL = `${BRIGHTID_APP_URL}/node/v6`
 const CONTEXT = process.env.VUE_APP_BRIGHTID_CONTEXT || 'clr.fund'
 

--- a/vue-app/src/api/bright-id.ts
+++ b/vue-app/src/api/bright-id.ts
@@ -46,7 +46,7 @@ export function getBrightIdLink(userAddress: string): string {
 }
 
 // This is for mobile app to launch BrightId app
-export function getBrightIdUnversalLink(userAddress: string): string {
+export function getBrightIdUniversalLink(userAddress: string): string {
   const deepLink = `${BRIGHTID_APP_URL}/link-verification/${CONTEXT}/${userAddress}`
   return deepLink
 }

--- a/vue-app/src/components/Links.vue
+++ b/vue-app/src/components/Links.vue
@@ -33,10 +33,7 @@ export default class extends Vue {
       this.to = this.href
     }
     if (typeof this.to === 'string') {
-      this.isExternal =
-        this.to.includes('http') ||
-        this.to.includes('mailto:') ||
-        this.to.includes('brightid:')
+      this.isExternal = this.to.includes('http') || this.to.includes('mailto:')
     }
   }
 }

--- a/vue-app/src/components/Links.vue
+++ b/vue-app/src/components/Links.vue
@@ -33,7 +33,10 @@ export default class extends Vue {
       this.to = this.href
     }
     if (typeof this.to === 'string') {
-      this.isExternal = this.to.includes('http') || this.to.includes('mailto:')
+      this.isExternal =
+        this.to.includes('http') ||
+        this.to.includes('mailto:') ||
+        this.to.includes('brightid:')
     }
   }
 }

--- a/vue-app/src/views/Verify.vue
+++ b/vue-app/src/views/Verify.vue
@@ -99,7 +99,8 @@
                   <em>
                     This link might look scary but it just makes a connection
                     between your connected wallet address, our app, and
-                    BrightID. Make sure your address looks correct.
+                    BrightID. If clicking the link does not open the BrightId
+                    app, try manually copying the link to a browser.
                   </em>
                 </p>
               </div>

--- a/vue-app/src/views/Verify.vue
+++ b/vue-app/src/views/Verify.vue
@@ -276,17 +276,14 @@ export default class VerifyView extends Vue {
     const checkVerification = async () => {
       await this.loadBrightId()
       isConditionMet = isConditionMetFn()
+
+      if (!isConditionMet) {
+        setTimeout(async () => {
+          await checkVerification()
+        }, intervalTime)
+      }
     }
     await checkVerification()
-
-    if (!isConditionMet) {
-      const intervalId = setInterval(async () => {
-        await checkVerification()
-        if (isConditionMet) {
-          clearInterval(intervalId)
-        }
-      }, intervalTime)
-    }
   }
 
   async loadBrightId() {

--- a/vue-app/src/views/Verify.vue
+++ b/vue-app/src/views/Verify.vue
@@ -145,7 +145,7 @@ import ProgressBar from '@/components/ProgressBar.vue'
 import QRCode from 'qrcode'
 import {
   getBrightIdLink,
-  getBrightIdUnversalLink,
+  getBrightIdUniversalLink,
   registerUser,
   BrightId,
 } from '@/api/bright-id'
@@ -224,8 +224,8 @@ export default class VerifyView extends Vue {
   mounted() {
     if (this.currentUser && !this.brightId?.isVerified) {
       // Present app link and QR code
-      this.appLink = getBrightIdLink(this.currentUser.walletAddress)
-      const qrcodeLink = getBrightIdUnversalLink(this.currentUser.walletAddress)
+      this.appLink = getBrightIdUniversalLink(this.currentUser.walletAddress)
+      const qrcodeLink = getBrightIdLink(this.currentUser.walletAddress)
       QRCode.toDataURL(qrcodeLink, (error, url: string) => {
         if (!error) {
           this.appLinkQrCode = url

--- a/vue-app/src/views/Verify.vue
+++ b/vue-app/src/views/Verify.vue
@@ -143,7 +143,12 @@ import Component from 'vue-class-component'
 import { Watch } from 'vue-property-decorator'
 import ProgressBar from '@/components/ProgressBar.vue'
 import QRCode from 'qrcode'
-import { getBrightIdLink, registerUser, BrightId } from '@/api/bright-id'
+import {
+  getBrightIdLink,
+  getBrightIdUnversalLink,
+  registerUser,
+  BrightId,
+} from '@/api/bright-id'
 import { User } from '@/api/user'
 import Transaction from '@/components/Transaction.vue'
 import Loader from '@/components/Loader.vue'
@@ -220,7 +225,8 @@ export default class VerifyView extends Vue {
     if (this.currentUser && !this.brightId?.isVerified) {
       // Present app link and QR code
       this.appLink = getBrightIdLink(this.currentUser.walletAddress)
-      QRCode.toDataURL(this.appLink, (error, url: string) => {
+      const qrcodeLink = getBrightIdUnversalLink(this.currentUser.walletAddress)
+      QRCode.toDataURL(qrcodeLink, (error, url: string) => {
         if (!error) {
           this.appLinkQrCode = url
         }


### PR DESCRIPTION
Use the BrightId universal mobile link instead of the schema link because clrfund incorrectly redirects schema link as internal link instead of external link and as a result cannot open the BrightId mobile app.

Also changed the BrightId status polling logic to only poll on timeout instead of on interval to avoid overloading the BrightId node potentially causing 503 service unavailable error.