### PR TITLE
Use Unitap to sponsor user as a temporary workaround

### DIFF
--- a/vue-app/src/views/AboutSybilResistance.vue
+++ b/vue-app/src/views/AboutSybilResistance.vue
@@ -70,7 +70,9 @@
       </li>
       <li>Get verified in BrightID so we know you're a human and not a bot.</li>
       <li>
-        Submit a transaction for clr.fund to sponsor you in BrightID.
+        Get sponsored by linking with a BrightID app, e.g.
+        <links to="https://unitap.app/gas-faucet" hideArrow="true">Unitap</links
+        >.
         <links
           to="https://medium.com/brightid/brightid-sponsorships-5327a8d39f1e"
           >More on BrightID sponsorship</links

--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -23,7 +23,7 @@
           What you'll need
           <img
             v-tooltip="{
-              content: `If you've previously donated to a CLR round, use the same wallet to bypass some BrightID steps`,
+              content: `If you've previously donated to a CLR round, you can skip the 'Get sponsored' and 'Get verified' steps`,
               trigger: 'hover click',
             }"
             width="16px"
@@ -47,8 +47,14 @@
               >Android</a
             >
             <ul>
-              <li><links to="/brightid/sponsor">Get sponsored</links></li>
               <li><links to="/brightid">Get verified</links></li>
+              <li>
+                Get sponsored (e.g by linking with
+                <links to="https://unitap.app/gas-faucet" hideArrow="true"
+                  >Unitap</links
+                >
+                or any BrightID app)
+              </li>
             </ul>
           </li>
           <li>An Ethereum wallet, with enough gas for two transactions</li>


### PR DESCRIPTION
Users occasionally get 'timeout waiting for sponsorship' from BrightID.

This PR is to temporary use Unitap to workaround the sponsorship issue…

A longer term solution is to switch to the sponsorship solution that does not use event logging on smart contract.
