### PR TITLE
Update BrightId guide and fix typos

### DIFF
--- a/vue-app/src/components/Accordion.vue
+++ b/vue-app/src/components/Accordion.vue
@@ -30,7 +30,8 @@ export default class Accordion extends Vue {
   @Prop() header
   @Prop() content
   @Prop() linkButton!: { link: string; text: string }
-  isOpen = false
+  @Prop({ default: false }) open!: boolean
+  isOpen = Boolean(this.open)
 
   toggleIsOpen() {
     this.isOpen = !this.isOpen

--- a/vue-app/src/views/BrightIdGuide.vue
+++ b/vue-app/src/views/BrightIdGuide.vue
@@ -3,10 +3,11 @@
     <h2 class="step-title">Get verified</h2>
     <p>
       BrightID verification helps prove that you’re a unique human. To get
-      verified, you need enough people to confirm they've met you and you're a
-      real person. There are a couple of ways to do this:
+      verified, you need to join a BrightId party where other members can verify
+      you're "not a bot".
     </p>
     <accordion
+      open="true"
       tag="🚀 Fastest"
       header="Join a BrightId party"
       content="BrightID run verification parties regularly. Join the call,
@@ -16,13 +17,6 @@
         link: 'https://meet.brightid.org/#/',
         text: 'View party schedule',
       }"
-    />
-    <accordion
-      tag="🎰 Luckiest"
-      header="Connect with 2 verified humans"
-      content="Know anyone that's contributed to Gitcoin Grants or clr.fund
-        rounds? They may already be verified. Hit them up and see if
-        they can verify you!"
     />
   </div>
 </template>

--- a/vue-app/src/views/Landing.vue
+++ b/vue-app/src/views/Landing.vue
@@ -142,7 +142,7 @@
           <h2>Built using the CLR protocol</h2>
           <p>
             clr.fund is a protocol for efficiently allocating funds to public
-            goods that benefit the Ethereum Network according to the prefences
+            goods that benefit the Ethereum Network according to the preferences
             of the Ethereum Community.
           </p>
           <links to="/about">About clr.fund</links>

--- a/vue-app/src/views/VerifyLanding.vue
+++ b/vue-app/src/views/VerifyLanding.vue
@@ -57,7 +57,7 @@
               </li>
             </ul>
           </li>
-          <li>An Ethereum wallet, with enough gas for two transactions</li>
+          <li>An Ethereum wallet, with enough gas for one transaction</li>
           <li>Access to Zoom or Google Meet</li>
         </ul>
         <links to="/about/sybil-resistance">Why is this important?</links>


### PR DESCRIPTION
Remove the option to get verified as BrightID user by connecting with 2 other verified users as this option no longer work.