### PR TITLE
Cart not opening when DAI balance < 0.0000001 DAI

### DIFF
--- a/vue-app/src/utils/amounts.ts
+++ b/vue-app/src/utils/amounts.ts
@@ -26,6 +26,12 @@ export function formatAmount(
       maximumSignificantDigits,
     }).format(result)
   }
-  // Else, return commified result
-  return commify(result)
+
+  try {
+    // Else, return commified result
+    return commify(result)
+  } catch {
+    // return result without comma if failed to add comma
+    return result.toString(10)
+  }
 }


### PR DESCRIPTION
This is a temporary fix, a more permanent fix should refactor the formatAmount function to break down the function and to avoid potentially converting big numbers into javascript number which is smaller than big number.

The bug being fixed here is to avoid ethers library throwing when it detected unsafe number passed to the commify function.