### PR TITLE
Only translate category if value is available and only process markdown if text is available

### DIFF
--- a/vue-app/src/components/Markdown.vue
+++ b/vue-app/src/components/Markdown.vue
@@ -15,7 +15,7 @@ export default class Transaction extends Vue {
   raw!: string
 
   get body(): string {
-    return markdown.render(this.raw)
+    return this.raw ? markdown.render(this.raw) : ''
   }
 }
 </script>

--- a/vue-app/src/components/ProjectListItem.vue
+++ b/vue-app/src/components/ProjectListItem.vue
@@ -4,7 +4,7 @@
       <links :to="projectRoute">
         <div class="project-image">
           <img :src="projectImageUrl" :alt="project.name" />
-          <div class="tag">
+          <div v-if="project.category" class="tag">
             {{ $t($store.getters.categoryLocaleKey(project.category)) }}
           </div>
         </div>

--- a/vue-app/src/components/ProjectProfile.vue
+++ b/vue-app/src/components/ProjectProfile.vue
@@ -24,7 +24,7 @@
       </h1>
       <p class="tagline">{{ project.tagline }}</p>
       <div class="subtitle">
-        <div class="tag">
+        <div v-if="project.category" class="tag">
           {{ $t($store.getters.categoryLocaleKey(project.category)) }}
           {{ $t('projectProfile.div1') }}
         </div>

--- a/vue-app/src/store/getters.ts
+++ b/vue-app/src/store/getters.ts
@@ -258,7 +258,7 @@ const getters = {
     () =>
     (category = ''): string => {
       try {
-        return `dynamic.category.${category.toLowerCase()}`
+        return category ? `dynamic.category.${category.toLowerCase()}` : ''
       } catch {
         return category
       }

--- a/vue-app/src/views/Join.vue
+++ b/vue-app/src/views/Join.vue
@@ -552,7 +552,7 @@
                 </div>
                 <div class="summary">
                   <h4 class="read-only-title">{{ $t('join.step5.h4_4') }}</h4>
-                  <div class="data">
+                  <div v-if="form.project.category" class="data">
                     {{
                       $t(
                         $store.getters.categoryLocaleKey(form.project.category)


### PR DESCRIPTION
On the clrfund canonical site, the category is not available on the project profile causing a lot of errors logged in the console log.
Projects also missing text to be rendered with markdown causing lots of error on the console log.  Do not call markdown, if text is missing. 