### PR TITLE
Make dark theme the default theme

### DIFF
--- a/vue-app/src/App.vue
+++ b/vue-app/src/App.vue
@@ -36,7 +36,7 @@
 import Vue from 'vue'
 import { Component, Watch } from 'vue-property-decorator'
 
-import { getOsColorScheme } from '@/utils/theme'
+import { getDefaultColorScheme } from '@/utils/theme'
 import { getCurrentRound } from '@/api/round'
 import { User } from '@/api/user'
 
@@ -163,7 +163,7 @@ export default class App extends Vue {
   @Watch('$store.state.theme')
   setAppTheme = () => {
     const savedTheme = this.$store.state.theme
-    const theme = savedTheme || getOsColorScheme()
+    const theme = savedTheme || getDefaultColorScheme()
     document.documentElement.setAttribute('data-theme', theme)
   }
 

--- a/vue-app/src/components/NavBar.vue
+++ b/vue-app/src/components/NavBar.vue
@@ -84,7 +84,7 @@ import { chain, ThemeMode } from '@/api/core'
 import Trans from '@/plugins/i18n/translations'
 import { TOGGLE_THEME } from '@/store/mutation-types'
 import { lsGet, lsSet } from '@/utils/localStorage'
-import { isValidTheme, getOsColorScheme } from '@/utils/theme'
+import { isValidTheme, getDefaultColorScheme } from '@/utils/theme'
 import ClickOutside from '@/directives/ClickOutside'
 
 @Component({
@@ -140,7 +140,9 @@ export default class NavBar extends Vue {
 
   created() {
     const savedTheme = lsGet(this.themeKey)
-    const theme = isValidTheme(savedTheme) ? savedTheme : getOsColorScheme()
+    const theme = isValidTheme(savedTheme)
+      ? savedTheme
+      : getDefaultColorScheme()
     this.$store.commit(TOGGLE_THEME, theme)
 
     const savedLanguage = lsGet(this.languageKey)

--- a/vue-app/src/utils/theme.ts
+++ b/vue-app/src/utils/theme.ts
@@ -2,9 +2,8 @@ import { ThemeMode } from '@/api/core'
 
 const PREFER_COLOR_SCHEME = '(prefers-color-scheme: dark)'
 
-export function getOsColorScheme(): ThemeMode {
-  const { matches } = window.matchMedia(PREFER_COLOR_SCHEME)
-  const colorScheme = matches ? ThemeMode.DARK : ThemeMode.LIGHT
+export function getDefaultColorScheme(): ThemeMode {
+  const colorScheme = ThemeMode.DARK
   return colorScheme
 }
 


### PR DESCRIPTION
This PR set the dark theme as the default theme because the app currently looks better in dark theme and when we do custom branding, this will make it easier to just customize the dark theme styles.