### PR TITLE
Fix BrightId sponsor error 68

### DIFF
--- a/vue-app/src/api/bright-id.ts
+++ b/vue-app/src/api/bright-id.ts
@@ -246,7 +246,9 @@ async function netlifySponsor(userAddress: string): Promise<SponsorData> {
     body: JSON.stringify({ userAddress }),
   })
 
-  return res.json()
+  const json = await res.json()
+
+  return json.statusCode === 200 ? json.body : { error: json.body }
 }
 
 /**
@@ -260,7 +262,7 @@ export async function sponsorUser(userAddress: string): Promise<SponsorData> {
   }
 
   try {
-    return netlifySponsor(userAddress)
+    return await netlifySponsor(userAddress)
   } catch (err) {
     if (err instanceof Error) {
       return { error: (err as Error).message }

--- a/vue-app/src/api/bright-id.ts
+++ b/vue-app/src/api/bright-id.ts
@@ -257,8 +257,8 @@ async function netlifySponsor(userAddress: string): Promise<SponsorData> {
     body: JSON.stringify({ userAddress }),
   })
 
-  /* eslint-disable-next-line no-console */
   const json = await res.json()
+  /* eslint-disable-next-line no-console */
   console.log('netlify sponsor response debug', res, json)
 
   if (res.status === 200) {

--- a/vue-app/src/api/bright-id.ts
+++ b/vue-app/src/api/bright-id.ts
@@ -258,8 +258,8 @@ async function netlifySponsor(userAddress: string): Promise<SponsorData> {
   })
 
   /* eslint-disable-next-line no-console */
-  console.log('netlify sponsor response debug', res)
   const json = await res.json()
+  console.log('netlify sponsor response debug', res, json)
 
   if (res.status === 200) {
     return json

--- a/vue-app/src/api/bright-id.ts
+++ b/vue-app/src/api/bright-id.ts
@@ -12,12 +12,22 @@ const CONTEXT = process.env.VUE_APP_BRIGHTID_CONTEXT || 'clr.fund'
 
 /**
  * These errors from the BrightID sponsor api can be ignored
+ * https://github.com/BrightID/BrightID-Node/blob/8093479a60da07c3cd2be32fe4fd8382217c966e/web_services/foxx/brightid/errors.js
+ *
  * 39 - The app generated id was sponsored before
- * 68 - sponsorship already sent
+ * 63 - Spend request for this app-generated id submitted before.
+ * 68 - The app has sent this sponsor request recently
  */
-const IGNORE_BRIGHTID_ERRORS = [39, 68]
+const IGNORE_BRIGHTID_ERRORS = [39, 63, 68]
 
+/**
+ * Check if the error number is in the ignore list.
+ * @param errorNum error number to check
+ * @returns true if the error is one of the IGNORE_BRIGHTID_ERROS
+ */
 function canIgnoreError(errorNum: number) {
+  /* eslint-disable-next-line no-console */
+  console.warn('BrightID error', errorNum)
   return IGNORE_BRIGHTID_ERRORS.includes(errorNum)
 }
 

--- a/vue-app/src/api/bright-id.ts
+++ b/vue-app/src/api/bright-id.ts
@@ -249,7 +249,7 @@ async function netlifySponsor(userAddress: string): Promise<SponsorData> {
   const json = await res.json()
 
   /* eslint-disable-next-line no-console */
-  console.log('netlify sponsor response debug', json)
+  console.log('netlify sponsor response debug', res, json)
 
   return json.statusCode === 200
     ? json.body

--- a/vue-app/src/api/bright-id.ts
+++ b/vue-app/src/api/bright-id.ts
@@ -246,14 +246,9 @@ async function netlifySponsor(userAddress: string): Promise<SponsorData> {
     body: JSON.stringify({ userAddress }),
   })
 
-  const json = await res.json()
-
   /* eslint-disable-next-line no-console */
-  console.log('netlify sponsor response debug', res, json)
-
-  return json.statusCode === 200
-    ? json.body
-    : { error: json.body || 'empty error' }
+  console.log('netlify sponsor response debug', res)
+  return res.json()
 }
 
 /**

--- a/vue-app/src/api/bright-id.ts
+++ b/vue-app/src/api/bright-id.ts
@@ -12,10 +12,10 @@ const CONTEXT = process.env.VUE_APP_BRIGHTID_CONTEXT || 'clr.fund'
 
 /**
  * These errors from the BrightID sponsor api can be ignored
+ * 39 - The app generated id was sponsored before
  * 68 - sponsorship already sent
- * 69 - The app generated id was sponsored before
  */
-const IGNORE_BRIGHTID_ERRORS = [68, 69]
+const IGNORE_BRIGHTID_ERRORS = [39, 68]
 
 function canIgnoreError(errorNum: number) {
   return IGNORE_BRIGHTID_ERRORS.includes(errorNum)

--- a/vue-app/src/api/bright-id.ts
+++ b/vue-app/src/api/bright-id.ts
@@ -258,9 +258,6 @@ async function netlifySponsor(userAddress: string): Promise<SponsorData> {
   })
 
   const json = await res.json()
-  /* eslint-disable-next-line no-console */
-  console.log('netlify sponsor response debug', res, json)
-
   if (res.status === 200) {
     return json
   }
@@ -269,7 +266,7 @@ async function netlifySponsor(userAddress: string): Promise<SponsorData> {
     return { hash: '0x0' }
   }
 
-  // return the error in the json body
+  // return the error
   return json
 }
 

--- a/vue-app/src/api/bright-id.ts
+++ b/vue-app/src/api/bright-id.ts
@@ -248,7 +248,12 @@ async function netlifySponsor(userAddress: string): Promise<SponsorData> {
 
   const json = await res.json()
 
-  return json.statusCode === 200 ? json.body : { error: json.body }
+  /* eslint-disable-next-line no-console */
+  console.log('netlify sponsor response debug', json)
+
+  return json.statusCode === 200
+    ? json.body
+    : { error: json.body || 'empty error' }
 }
 
 /**

--- a/vue-app/src/lambda/sponsor.js
+++ b/vue-app/src/lambda/sponsor.js
@@ -9,8 +9,8 @@ const NODE_URL =
  * @param errorMessage error message
  * @returns error object
  */
-function makeError(errorMessage) {
-  const body = JSON.stringify({ error: errorMessage })
+function makeError(errorMessage, errorNum) {
+  const body = JSON.stringify({ error: errorMessage, errorNum })
   return { statusCode: 400, body }
 }
 
@@ -92,11 +92,7 @@ async function handleSponsorRequest(userAddress) {
   const json = await res.json()
 
   if (json.error) {
-    if (json.errorNum === 68) {
-      // sponsorship already sent recently, ignore this error
-      return makeResult({ hash: '0x0' })
-    }
-    return makeError(json.errorMessage)
+    return makeError(json.errorMessage, json.errorNum)
   }
 
   if (json.data) {

--- a/vue-app/src/lambda/sponsor.js
+++ b/vue-app/src/lambda/sponsor.js
@@ -52,7 +52,7 @@ async function handleSponsorRequest(userAddress) {
 
   if (!brightIdSponsorKey) {
     throw new Error(
-      'Environment VUE_APP_BRIGHTID_SPONSOR_KEY_FOR_NETLIFY not set'
+      'Environment variable VUE_APP_BRIGHTID_SPONSOR_KEY_FOR_NETLIFY not set'
     )
   }
 
@@ -120,6 +120,6 @@ exports.handler = async function (event) {
 
     return await handleSponsorRequest(jsonBody.userAddress)
   } catch (err) {
-    return makeError(err.message + ' ' + event.body)
+    return makeError(err.message)
   }
 }

--- a/vue-app/src/lambda/sponsor.js
+++ b/vue-app/src/lambda/sponsor.js
@@ -10,11 +10,7 @@ const NODE_URL =
  * @returns error object
  */
 function makeError(errorMessage) {
-  const body =
-    typeof errorMessage === 'string'
-      ? errorMessage
-      : JSON.stringify(errorMessage)
-
+  const body = JSON.stringify({ error: errorMessage })
   return { statusCode: 400, body }
 }
 
@@ -24,7 +20,7 @@ function makeError(errorMessage) {
  * @returns result object
  */
 function makeResult(result) {
-  const body = typeof result === 'object' ? JSON.stringify(result) : result
+  const body = JSON.stringify(result)
   return { statusCode: 200, body }
 }
 
@@ -101,9 +97,13 @@ async function handleSponsorRequest(userAddress) {
       return makeResult({ hash: '0x0' })
     }
     return makeError(json.errorMessage)
-  } else {
-    return makeResult(json.data)
   }
+
+  if (json.data) {
+    return makeResult({ hash: json.data.hash })
+  }
+
+  return makeError('Unexpected result from the BrightID sponsorship API.')
 }
 
 /**

--- a/vue-app/src/lambda/sponsor.js
+++ b/vue-app/src/lambda/sponsor.js
@@ -118,7 +118,7 @@ exports.handler = async function (event) {
       return makeError('Missing userAddress in request body: ' + event.body)
     }
 
-    return handleSponsorRequest(jsonBody.userAddress)
+    return await handleSponsorRequest(jsonBody.userAddress)
   } catch (err) {
     return makeError(err.message + ' ' + event.body)
   }

--- a/vue-app/src/views/Verify.vue
+++ b/vue-app/src/views/Verify.vue
@@ -129,6 +129,7 @@
             >
             </transaction>
             <div class="qr">
+              <loader v-if="!appLink"></loader>
               <div class="instructions" v-if="appLink">
                 <p class="desktop" v-if="appLinkQrCode">
                   {{ $t('verify.p4') }}

--- a/vue-app/src/views/Verify.vue
+++ b/vue-app/src/views/Verify.vue
@@ -129,7 +129,7 @@
             >
             </transaction>
             <div class="qr">
-              <loader v-if="!appLink"></loader>
+              <loader v-if="!appLink && !autoSponsorError"></loader>
               <div class="instructions" v-if="appLink">
                 <p class="desktop" v-if="appLinkQrCode">
                   {{ $t('verify.p4') }}


### PR DESCRIPTION
This PR is to ignore the BrightID sponsor error 68, The app generated id was sponsored before, so that users can link their wallet with their BrightID account on subsequent rounds.