### PR TITLE
Hide the 'Get Started' button and show the 'Join round' callout

### DIFF
--- a/vue-app/src/views/Landing.vue
+++ b/vue-app/src/views/Landing.vue
@@ -14,13 +14,15 @@
               {{ $t('landing.hero.subtitle') }}
             </div>
             <div class="btn-group">
-              <div class="btn-action" @click="gotoLeaderboardOrProjectsPage">{{ $t('landing.hero.action') }}</div>
+              <div v-if="currentRound" class="btn-action" @click="gotoLeaderboardOrProjectsPage">
+                {{ $t('landing.hero.action') }}
+              </div>
               <div class="btn-info" @click="scrollToHowItWorks">
                 {{ $t('landing.hero.info') }}
               </div>
             </div>
           </div>
-          <div class="apply-callout" v-if="isRoundJoinPhase && !isRecipientRegistryFull">
+          <div class="apply-callout" v-if="(!currentRound || isRoundJoinPhase) && !isRecipientRegistryFull">
             <div class="column">
               <h2>{{ $t('landing.callout.title') }}</h2>
               <p>


### PR DESCRIPTION
On the landing page, when there's no scheduled round, we want to show the 'Join round' callout to attract projects to join the round to be scheduled in the future.