### PR TITLE
Fix image upload validation

### DIFF
--- a/vue-app/src/locales/cn.json
+++ b/vue-app/src/locales/cn.json
@@ -1199,7 +1199,7 @@
         "donation": "捐款细节",
         "team": "团队",
         "links": "链接",
-        "images": "图片",
+        "image": "图片",
         "review": "审查",
         "submit": "提交"
       }

--- a/vue-app/src/locales/en.json
+++ b/vue-app/src/locales/en.json
@@ -1199,7 +1199,7 @@
         "donation": "Donation details",
         "team": "Team details",
         "links": "Links",
-        "images": "Images",
+        "image": "Images",
         "review": "Review",
         "submit": "Submit"
       }

--- a/vue-app/src/locales/es.json
+++ b/vue-app/src/locales/es.json
@@ -1199,7 +1199,7 @@
         "donation": "Detalles de la donación",
         "team": "Detalles del equipo",
         "links": "Enlaces",
-        "images": "Imágenes",
+        "image": "Imágenes",
         "review": "Revisa",
         "submit": "Enviar"
       }

--- a/vue-app/src/views/JoinView.vue
+++ b/vue-app/src/views/JoinView.vue
@@ -772,11 +772,13 @@ const rules = computed(() => {
     image: {
       bannerHash: {
         required,
-        validIpfsHash: isIPFS.cid,
+        validIpfsHash,
+        $autoDirty: true,
       },
       thumbnailHash: {
         required,
-        validIpfsHash: isIPFS.cid,
+        validIpfsHash,
+        $autoDirty: true,
       },
     },
   }
@@ -784,12 +786,17 @@ const rules = computed(() => {
 const v$ = useVuelidate(rules, form)
 
 const currentStep = ref<number>(0)
-const steps = ['project', 'donation', 'team', 'links', 'images', 'review', 'submit', 'confirm']
+const steps = ['project', 'donation', 'team', 'links', 'image', 'review', 'submit', 'confirm']
 const stepNames = steps.slice(0, steps.length - 1)
 const showSummaryPreview = ref(false)
 const isWaiting = ref(false)
 const txHash = ref('')
 const txError = ref('')
+
+function validIpfsHash(hash: string): boolean {
+  const isValid = Boolean(hash) && isIPFS.cid(hash)
+  return isValid
+}
 
 const isNavDisabled = computed<boolean>(
   () => !isStepValid(currentStep.value) && currentStep.value !== form.furthestStep,
@@ -860,6 +867,7 @@ function saveFormData(updateFurthest?: boolean): void {
 // Callback from IpfsImageUpload component
 function handleUpload(key, value) {
   form.image[key] = value
+  v$.value.image[key].$touch()
   saveFormData(false)
 }
 
@@ -872,6 +880,7 @@ function isStepValid(step: number): boolean {
     return isLinkStepValid()
   }
   const stepName: string = steps[step]
+
   return !v$.value[stepName]?.$invalid
 }
 


### PR DESCRIPTION
Currently, on the application form, users can navigate to the submission page without uploading logo images. This PR makes sure images are uploaded before allowing navigation to the next page.