### PR TITLE
Fix 504 gateway timeout error in dev

### DIFF
--- a/vue-app/vite.config.ts
+++ b/vue-app/vite.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
     alias: { '@': path.resolve(__dirname, 'src'), ...nodeStdlibBrowser },
   },
   optimizeDeps: {
+    include: ['@clrfund/maci-utils'],
     esbuildOptions: {
       target: 'esnext', // to enable nable Big integer literals
       inject: [require.resolve('node-stdlib-browser/helpers/esbuild/shim')],


### PR DESCRIPTION
In dev mode, we occasionally get the 504 error while loading the maci-utils library, pre-bundling seems to solve the issue.