### PR TITLE
Fix incorrect formatted amounts when token decimals is not 18

### DIFF
--- a/vue-app/src/api/claims.ts
+++ b/vue-app/src/api/claims.ts
@@ -1,4 +1,4 @@
-import { Contract, FixedNumber } from 'ethers'
+import { Contract, BigNumber } from 'ethers'
 import sdk from '@/graphql/sdk'
 
 import { FundingRound } from './abi'
@@ -9,10 +9,10 @@ export async function getAllocatedAmount(
   tokenDecimals: number,
   result: string,
   spent: string,
-): Promise<FixedNumber> {
+): Promise<BigNumber> {
   const fundingRound = new Contract(fundingRoundAddress, FundingRound, provider)
   const allocatedAmount = await fundingRound.getAllocatedAmount(result, spent)
-  return FixedNumber.fromValue(allocatedAmount, tokenDecimals)
+  return allocatedAmount
 }
 
 export async function isFundsClaimed(

--- a/vue-app/src/api/factory.ts
+++ b/vue-app/src/api/factory.ts
@@ -1,4 +1,4 @@
-import { FixedNumber } from 'ethers'
+import { BigNumber } from 'ethers'
 import { factory } from './core'
 import sdk from '@/graphql/sdk'
 
@@ -8,14 +8,14 @@ export interface Factory {
   nativeTokenSymbol: string
   nativeTokenDecimals: number
   userRegistryAddress: string
-  matchingPool: FixedNumber
+  matchingPool: BigNumber
 }
 
 export async function getFactoryInfo() {
   let nativeTokenAddress = ''
   let nativeTokenSymbol = ''
   let nativeTokenDecimals = 0
-  let matchingPool = FixedNumber.from(0)
+  let matchingPool = BigNumber.from(0)
   let userRegistryAddress = ''
   let recipientRegistryAddress = ''
 
@@ -39,7 +39,7 @@ export async function getFactoryInfo() {
   }
 
   try {
-    matchingPool = await getMatchingFunds(nativeTokenAddress, nativeTokenDecimals)
+    matchingPool = await getMatchingFunds(nativeTokenAddress)
   } catch (err) {
     /* eslint-disable-next-line no-console */
     console.error('Failed to get matching pool', err)
@@ -56,7 +56,7 @@ export async function getFactoryInfo() {
   }
 }
 
-export async function getMatchingFunds(nativeTokenAddress: string, nativeTokenDecimals: number): Promise<FixedNumber> {
+export async function getMatchingFunds(nativeTokenAddress: string): Promise<BigNumber> {
   const matchingFunds = await factory.getMatchingFunds(nativeTokenAddress)
-  return FixedNumber.fromValue(matchingFunds, nativeTokenDecimals)
+  return matchingFunds
 }

--- a/vue-app/src/api/round.ts
+++ b/vue-app/src/api/round.ts
@@ -1,4 +1,4 @@
-import { BigNumber, Contract, utils, FixedNumber } from 'ethers'
+import { BigNumber, Contract, utils } from 'ethers'
 import { DateTime } from 'luxon'
 import { PubKey } from '@clrfund/maci-utils'
 
@@ -30,9 +30,9 @@ export interface RoundInfo {
   startTime: DateTime
   signUpDeadline: DateTime
   votingDeadline: DateTime
-  totalFunds: FixedNumber
-  matchingPool: FixedNumber
-  contributions: FixedNumber
+  totalFunds: BigNumber
+  matchingPool: BigNumber
+  contributions: BigNumber
   contributors: number
   messages: number
   blogUrl?: string
@@ -103,9 +103,9 @@ function toRoundInfo(data: any, network: string): RoundInfo {
     startTime: DateTime.fromSeconds(data.startTime),
     signUpDeadline: DateTime.fromSeconds(Number(data.startTime) + Number(data.signUpDuration)),
     votingDeadline: DateTime.fromSeconds(Number(data.startTime) + Number(data.votingDuration)),
-    totalFunds: FixedNumber.fromValue(totalFunds, nativeTokenDecimals),
-    matchingPool: FixedNumber.fromValue(matchingPool, nativeTokenDecimals),
-    contributions: FixedNumber.fromValue(contributions, nativeTokenDecimals),
+    totalFunds,
+    matchingPool,
+    contributions,
     contributors: data.contributorCount,
     messages: Number(data.messages),
     blogUrl: data.blogUrl,
@@ -240,9 +240,9 @@ export async function getRoundInfo(
     startTime,
     signUpDeadline,
     votingDeadline,
-    totalFunds: FixedNumber.fromValue(totalFunds, nativeTokenDecimals),
-    matchingPool: FixedNumber.fromValue(matchingPool, nativeTokenDecimals),
-    contributions: FixedNumber.fromValue(contributions, nativeTokenDecimals),
+    totalFunds,
+    matchingPool,
+    contributions,
     contributors,
     messages: messages.toNumber(),
   }

--- a/vue-app/src/components/ClaimButton.vue
+++ b/vue-app/src/components/ClaimButton.vue
@@ -27,13 +27,12 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
-import type { FixedNumber } from 'ethers'
+import type { BigNumber } from 'ethers'
 
 import { getAllocatedAmount, isFundsClaimed } from '@/api/claims'
 import type { Project } from '@/api/projects'
 import { RoundStatus } from '@/api/round'
 import { formatAmount as _formatAmount } from '@/utils/amounts'
-import { markdown } from '@/utils/markdown'
 
 import ClaimModal from '@/components/ClaimModal.vue'
 import Loader from '@/components/Loader.vue'
@@ -52,7 +51,7 @@ interface Props {
 
 const props = defineProps<Props>()
 
-const allocatedAmount = ref<FixedNumber | null>(null)
+const allocatedAmount = ref<BigNumber | null>(null)
 const claimed = ref<boolean | null>(null)
 const isLoading = ref(true)
 
@@ -118,7 +117,7 @@ function canClaim(): boolean {
   return hasClaimBtn() && !!currentUser.value && !claimed.value
 }
 
-function formatAmount(value: FixedNumber): string {
+function formatAmount(value: BigNumber): string {
   const maxDecimals = 6
   const { nativeTokenDecimals } = currentRound.value!
   return _formatAmount(value, nativeTokenDecimals, null, maxDecimals)

--- a/vue-app/src/components/MatchingFundsModal.vue
+++ b/vue-app/src/components/MatchingFundsModal.vue
@@ -92,7 +92,7 @@ const balance = computed<string | null>(() => {
   if (balance === null || typeof balance === 'undefined') {
     return null
   }
-  return formatUnits(balance, 18)
+  return formatUnits(balance, nativeTokenDecimals.value)
 })
 const renderBalance = computed<string | null>(() => {
   const balance: BigNumber | null | undefined = userStore.currentUser?.balance

--- a/vue-app/src/components/RoundInformation.vue
+++ b/vue-app/src/components/RoundInformation.vue
@@ -336,7 +336,7 @@ const formatTotalInRound = computed(() => {
   }
 
   const { contributions, matchingPool } = roundInfo.value
-  const totalInRound = contributions.addUnsafe(matchingPool)
+  const totalInRound = contributions.add(matchingPool)
 
   return formatAmount(totalInRound)
 })
@@ -388,7 +388,7 @@ function formatDate(value: DateTime): string {
   return value.toLocaleString(DateTime.DATETIME_SHORT) || ''
 }
 
-function formatAmount(value: BigNumber | FixedNumber | string): string {
+function formatAmount(value: BigNumber | string): string {
   if (!nativeTokenDecimals.value) {
     return ''
   }

--- a/vue-app/src/stores/app.ts
+++ b/vue-app/src/stores/app.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { FixedNumber, type BigNumber } from 'ethers'
+import { BigNumber } from 'ethers'
 import {
   type CartItem,
   type Contributor,
@@ -152,10 +152,10 @@ export const useAppStore = defineStore('app', {
         return factory.userRegistryAddress
       }
     },
-    matchingPool: (state): FixedNumber => {
+    matchingPool: (state): BigNumber => {
       const { currentRound, factory } = state
 
-      let matchingPool = FixedNumber.from(0)
+      let matchingPool = BigNumber.from(0)
 
       if (factory) {
         matchingPool = factory.matchingPool

--- a/vue-app/src/utils/amounts.ts
+++ b/vue-app/src/utils/amounts.ts
@@ -1,8 +1,8 @@
-import type { BigNumber, BigNumberish, FixedNumber } from 'ethers'
+import type { BigNumber, BigNumberish } from 'ethers'
 import { commify, formatUnits } from '@ethersproject/units'
 
 export function formatAmount(
-  _value: BigNumber | FixedNumber | string,
+  _value: BigNumber | string,
   units: BigNumberish = 18,
   maximumSignificantDigits?: number | null,
   maxDecimals?: number | null,

--- a/vue-app/src/views/TransactionSuccess.vue
+++ b/vue-app/src/views/TransactionSuccess.vue
@@ -66,9 +66,11 @@ import { useRouter } from 'vue-router'
 const route = useRoute()
 const router = useRouter()
 const appStore = useAppStore()
-const { contribution, currentRound } = storeToRefs(appStore)
+const { contribution, currentRound, nativeTokenDecimals } = storeToRefs(appStore)
 
-const formatContribution = computed(() => (contribution.value ? formatAmount(contribution.value, 18) : ''))
+const formatContribution = computed(() =>
+  contribution.value ? formatAmount(contribution.value, nativeTokenDecimals.value) : '',
+)
 const hash = computed(() => route.params.hash as string)
 function redirectToProjects() {
   router.push({ name: 'projects' })


### PR DESCRIPTION
When the native token decimal is not 18 (i.e. USDC is 6), the formatted amounts showing on the round information page will be incorrect. For example, a contribution of 20 USDC will show up as 20T USDC.

Users also cannot contribute to the matching pool due to incorrect amount calculation.
This bug also show incorrect claim amount on the project page after the round is finalized.