### PR TITLE
Reallocation being ignored

### DIFF
--- a/subgraph/src/MACIMapping.ts
+++ b/subgraph/src/MACIMapping.ts
@@ -91,24 +91,24 @@ export function handleSignUp(event: SignUp): void {
 
   //NOTE: If the public keys aren't being tracked initialize them
   if (publicKey == null) {
-    let publicKey = new PublicKey(publicKeyId)
-    publicKey.x = event.params._userPubKey.x
-    publicKey.y = event.params._userPubKey.y
-    publicKey.stateIndex = event.params._stateIndex
-
-    publicKey.voiceCreditBalance = event.params._voiceCreditBalance
-
-    let fundingRoundAddress = event.transaction.to!
-    let fundingRoundId = fundingRoundAddress.toHex()
-    let fundingRound = FundingRound.load(fundingRoundId)
-    if (fundingRound == null) {
-      log.error('Error: handleSignUp failed, fundingRound not registered', [])
-      return
-    }
-
-    publicKey.fundingRound = fundingRoundId
-    publicKey.save()
+    publicKey = new PublicKey(publicKeyId)
   }
+  publicKey.x = event.params._userPubKey.x
+  publicKey.y = event.params._userPubKey.y
+  publicKey.stateIndex = event.params._stateIndex
+
+  publicKey.voiceCreditBalance = event.params._voiceCreditBalance
+
+  let fundingRoundAddress = event.transaction.to!
+  let fundingRoundId = fundingRoundAddress.toHex()
+  let fundingRound = FundingRound.load(fundingRoundId)
+  if (fundingRound == null) {
+    log.error('Error: handleSignUp failed, fundingRound not registered', [])
+    return
+  }
+
+  publicKey.fundingRound = fundingRoundId
+  publicKey.save()
 
   log.info('SignUp', [])
 }

--- a/vue-app/src/api/contributions.ts
+++ b/vue-app/src/api/contributions.ts
@@ -162,7 +162,11 @@ export async function getContributorIndex(fundingRoundAddress: string, pubKey: P
     publicKeyId: id,
   })
 
-  return data.publicKey?.stateIndex ? Number(data.publicKey.stateIndex) : null
+  if (data.publicKeys.length === 0) {
+    return null
+  }
+
+  return Number(data.publicKeys[0].stateIndex)
 }
 
 /**

--- a/vue-app/src/components/Cart.vue
+++ b/vue-app/src/components/Cart.vue
@@ -417,7 +417,7 @@ const contribution = computed(() => appStore.contribution || BigNumber.from(0))
 const filteredCart = computed<CartItem[]>(() => {
   // Once reallocation phase ends, use committedCart for cart items
   if (hasReallocationPhaseEnded.value) {
-    return committedCart.value
+    return committedCart.value.filter(item => !item.isCleared)
   }
   // Hide cleared items
   return cart.value.filter(item => !item.isCleared)

--- a/vue-app/src/graphql/API.ts
+++ b/vue-app/src/graphql/API.ts
@@ -3146,12 +3146,12 @@ export type GetContributionsAmountQueryVariables = Exact<{
 export type GetContributionsAmountQuery = { __typename?: 'Query', contributions: Array<{ __typename?: 'Contribution', amount: any | null }> };
 
 export type GetContributorIndexQueryVariables = Exact<{
-  fundingRoundAddress: Scalars['ID'];
+  fundingRoundAddress: Scalars['String'];
   publicKeyId: Scalars['ID'];
 }>;
 
 
-export type GetContributorIndexQuery = { __typename?: 'Query', publicKey: { __typename?: 'PublicKey', id: string, stateIndex: any | null } | null };
+export type GetContributorIndexQuery = { __typename?: 'Query', publicKeys: Array<{ __typename?: 'PublicKey', id: string, stateIndex: any | null }> };
 
 export type GetContributorMessagesQueryVariables = Exact<{
   fundingRoundAddress: Scalars['String'];
@@ -3195,13 +3195,6 @@ export type GetProjectQueryVariables = Exact<{
 
 
 export type GetProjectQuery = { __typename?: 'Query', recipients: Array<{ __typename?: 'Recipient', id: string, requestType: string | null, recipientAddress: any | null, recipientMetadata: string | null, recipientIndex: any | null, submissionTime: string | null, rejected: boolean | null, verified: boolean | null }> };
-
-export type GetPublicKeyQueryVariables = Exact<{
-  pubKey: Scalars['ID'];
-}>;
-
-
-export type GetPublicKeyQuery = { __typename?: 'Query', publicKey: { __typename?: 'PublicKey', id: string } | null };
 
 export type GetRecipientQueryVariables = Exact<{
   registryAddress: Scalars['ID'];
@@ -3286,8 +3279,8 @@ export const GetContributionsAmountDocument = gql`
 }
     `;
 export const GetContributorIndexDocument = gql`
-    query GetContributorIndex($fundingRoundAddress: ID!, $publicKeyId: ID!) {
-  publicKey(id: $publicKeyId) {
+    query GetContributorIndex($fundingRoundAddress: String!, $publicKeyId: ID!) {
+  publicKeys(where: {id: $publicKeyId, fundingRound: $fundingRoundAddress}) {
     id
     stateIndex
   }
@@ -3364,13 +3357,6 @@ export const GetProjectDocument = gql`
     submissionTime
     rejected
     verified
-  }
-}
-    `;
-export const GetPublicKeyDocument = gql`
-    query GetPublicKey($pubKey: ID!) {
-  publicKey(id: $pubKey) {
-    id
   }
 }
     `;
@@ -3539,9 +3525,6 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     GetProject(variables: GetProjectQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetProjectQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetProjectQuery>(GetProjectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetProject', 'query');
-    },
-    GetPublicKey(variables: GetPublicKeyQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetPublicKeyQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetPublicKeyQuery>(GetPublicKeyDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetPublicKey', 'query');
     },
     GetRecipient(variables: GetRecipientQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetRecipientQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetRecipientQuery>(GetRecipientDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetRecipient', 'query');

--- a/vue-app/src/graphql/queries/GetContributorIndex.graphql
+++ b/vue-app/src/graphql/queries/GetContributorIndex.graphql
@@ -1,8 +1,8 @@
 query GetContributorIndex(
-  $fundingRoundAddress: ID!
+  $fundingRoundAddress: String!
   $publicKeyId: ID!
 ) {
-   publicKey(id: $publicKeyId) {
+   publicKeys(where: {id: $publicKeyId, fundingRound: $fundingRoundAddress}) {
     id
     stateIndex
   }

--- a/vue-app/src/graphql/queries/GetPublicKey.graphql
+++ b/vue-app/src/graphql/queries/GetPublicKey.graphql
@@ -1,5 +1,0 @@
-query GetPublicKey($pubKey: ID!) {
-  publicKey(id: $pubKey) {
-    id
-  }
-}


### PR DESCRIPTION
Contribution/Reallocation can be ignored if a user had previously contributed to a previous round.  

The issue was caused by the incorrect subgraph schema for PublicKey. A MACI public key for different round can have different MACI 'stateIndex'.  Currently, the subgraph mapping logic for a public key only updates the public key for the signup event for the first round a user contributed to.  It skips updating the public key with latest `stateIndex` value for subsequent rounds that the user contributes to.

