### PR TITLE
Quickfix: Add WalletConnect 1.0 bridge

### DIFF
--- a/vue-app/src/stores/wallet/connectors/WalletConnectConnector.ts
+++ b/vue-app/src/stores/wallet/connectors/WalletConnectConnector.ts
@@ -9,6 +9,7 @@ export default {
       rpc: {
         [rpcChainId]: rpcUrl,
       },
+      bridge: "https://walletconnect-relay.minerva.digital",
     })
 
     let accounts, chainId


### PR DESCRIPTION
WC 1.0 was shut down, but with this quickfix it works. Longterm you should switch to 2.0.