### PR TITLE
Make recipient id unique for different registries

### DIFF
--- a/contracts/contracts/recipientRegistry/BaseRecipientRegistry.sol
+++ b/contracts/contracts/recipientRegistry/BaseRecipientRegistry.sol
@@ -146,4 +146,19 @@ abstract contract BaseRecipientRegistry is IRecipientRegistry {
   function getRecipientCount() public view returns(uint256) {
       return slots.length - removed.length;
   }
+
+  /**
+   * @dev Make a unique recipient id for different registries
+   * @param _registry Recipient registry address
+   * @param _recipient Recipient address
+   * @param _metadata Recipient metadata
+   * @return recipient id
+   */
+   function makeRecipientId(address _registry, address _recipient, string calldata _metadata)
+    internal
+    pure
+    returns(bytes32)
+  {
+    return keccak256(abi.encodePacked(_registry, _recipient, _metadata));
+  }
 }

--- a/contracts/contracts/recipientRegistry/OptimisticRecipientRegistry.sol
+++ b/contracts/contracts/recipientRegistry/OptimisticRecipientRegistry.sol
@@ -97,7 +97,7 @@ contract OptimisticRecipientRegistry is Ownable, BaseRecipientRegistry {
   {
     require(_recipient != address(0), 'RecipientRegistry: Recipient address is zero');
     require(bytes(_metadata).length != 0, 'RecipientRegistry: Metadata info is empty string');
-    bytes32 recipientId = keccak256(abi.encodePacked(_recipient, _metadata));
+    bytes32 recipientId = makeRecipientId(address(this), _recipient, _metadata);
     require(recipients[recipientId].index == 0, 'RecipientRegistry: Recipient already registered');
     require(requests[recipientId].submissionTime == 0, 'RecipientRegistry: Request already submitted');
     require(msg.value == baseDeposit, 'RecipientRegistry: Incorrect deposit amount');

--- a/contracts/contracts/recipientRegistry/PermissionedRecipientRegistry.sol
+++ b/contracts/contracts/recipientRegistry/PermissionedRecipientRegistry.sol
@@ -97,7 +97,7 @@ contract PermissionedRecipientRegistry is Ownable, BaseRecipientRegistry {
   {
     require(_recipient != address(0), 'RecipientRegistry: Recipient address is zero');
     require(bytes(_metadata).length != 0, 'RecipientRegistry: Metadata info is empty string');
-    bytes32 recipientId = keccak256(abi.encodePacked(_recipient, _metadata));
+    bytes32 recipientId = makeRecipientId(address(this), _recipient, _metadata);
     require(recipients[recipientId].index == 0, 'RecipientRegistry: Recipient already registered');
     require(requests[recipientId].submissionTime == 0, 'RecipientRegistry: Request already submitted');
     require(msg.value == baseDeposit, 'RecipientRegistry: Incorrect deposit amount');

--- a/contracts/contracts/recipientRegistry/SimpleRecipientRegistry.sol
+++ b/contracts/contracts/recipientRegistry/SimpleRecipientRegistry.sol
@@ -47,7 +47,7 @@ contract SimpleRecipientRegistry is Ownable, BaseRecipientRegistry {
   {
     require(_recipient != address(0), 'RecipientRegistry: Recipient address is zero');
     require(bytes(_metadata).length != 0, 'RecipientRegistry: Metadata info is empty string');
-    bytes32 recipientId = keccak256(abi.encodePacked(_recipient, _metadata));
+    bytes32 recipientId = makeRecipientId(address(this), _recipient, _metadata);
     uint256 recipientIndex = _addRecipient(recipientId, _recipient);
     emit RecipientAdded(recipientId, _recipient, _metadata, recipientIndex, block.timestamp);
   }


### PR DESCRIPTION
This fix is important for subgraph mapping as the recipient id is used as the primary key in the `Recipient` entity. Duplicate keys can be generated if the recipiients from different registries have the exact same metadata and the recipientIndex can get overwritten.