### PR TITLE
Fix recipient registry subgraph mapping

### DIFF
--- a/subgraph/src/FundingRoundFactoryMapping.ts
+++ b/subgraph/src/FundingRoundFactoryMapping.ts
@@ -17,7 +17,7 @@ import { FundingRound as FundingRoundContract } from '../generated/FundingRoundF
 
 import { OptimisticRecipientRegistry as RecipientRegistryContract } from '../generated/FundingRoundFactory/OptimisticRecipientRegistry'
 import { BrightIdUserRegistry as BrightIdUserRegistryContract } from '../generated/FundingRoundFactory/BrightIdUserRegistry'
-import { loadRecipientRegistry } from './RecipientRegistry'
+import { createRecipientRegistry } from './RecipientRegistry'
 
 import {
   FundingRound as FundingRoundTemplate,
@@ -148,7 +148,10 @@ function createOrUpdateFundingRoundFactory(
   //Check if these registries already exist/are being tracked
   let recipientRegistryAddress = fundingRoundFactoryContract.recipientRegistry()
   let recipientRegistryId = recipientRegistryAddress.toHexString()
-  let recipientRegistry = loadRecipientRegistry(recipientRegistryAddress)
+  let recipientRegistry = RecipientRegistry.load(recipientRegistryId)
+  if (!recipientRegistry) {
+    createRecipientRegistry(fundingRoundFactoryId, recipientRegistryAddress)
+  }
 
   let contributorRegistryAddress = fundingRoundFactoryContract.userRegistry()
   let contributorRegistryId = contributorRegistryAddress.toHexString()

--- a/subgraph/src/FundingRoundFactoryMapping.ts
+++ b/subgraph/src/FundingRoundFactoryMapping.ts
@@ -17,6 +17,7 @@ import { FundingRound as FundingRoundContract } from '../generated/FundingRoundF
 
 import { OptimisticRecipientRegistry as RecipientRegistryContract } from '../generated/FundingRoundFactory/OptimisticRecipientRegistry'
 import { BrightIdUserRegistry as BrightIdUserRegistryContract } from '../generated/FundingRoundFactory/BrightIdUserRegistry'
+import { loadRecipientRegistry } from './RecipientRegistry'
 
 import {
   FundingRound as FundingRoundTemplate,
@@ -30,48 +31,6 @@ import {
   ContributorRegistry,
   Token,
 } from '../generated/schema'
-
-function createRecipientRegistry(
-  fundingRoundFactoryAddress: Address,
-  recipientRegistryAddress: Address
-): RecipientRegistry {
-  log.info('New recipientRegistry {}', [recipientRegistryAddress.toHex()])
-  let recipientRegistryId = recipientRegistryAddress.toHexString()
-  let recipientRegistry = new RecipientRegistry(recipientRegistryId)
-
-  recipientRegistryTemplate.create(recipientRegistryAddress)
-  let recipientRegistryContract = RecipientRegistryContract.bind(
-    recipientRegistryAddress
-  )
-  let baseDeposit = recipientRegistryContract.try_baseDeposit()
-  if (baseDeposit.reverted) {
-    recipientRegistry.baseDeposit = BigInt.fromI32(0)
-    recipientRegistry.challengePeriodDuration = BigInt.fromI32(0)
-  } else {
-    recipientRegistry.baseDeposit = baseDeposit.value
-    let challengePeriodDuration =
-      recipientRegistryContract.challengePeriodDuration()
-    recipientRegistry.challengePeriodDuration = challengePeriodDuration
-  }
-  let controller = recipientRegistryContract.try_controller()
-  let maxRecipients = recipientRegistryContract.try_maxRecipients()
-  let owner = recipientRegistryContract.try_owner()
-
-  if (!controller.reverted) {
-    recipientRegistry.controller = controller.value
-  }
-  if (!maxRecipients.reverted) {
-    recipientRegistry.maxRecipients = maxRecipients.value
-  }
-  if (!owner.reverted) {
-    recipientRegistry.owner = owner.value
-  }
-  recipientRegistry.fundingRoundFactory =
-    fundingRoundFactoryAddress.toHexString()
-  recipientRegistry.save()
-
-  return recipientRegistry
-}
 
 function createContributorRegistry(
   fundingRoundFactoryAddress: Address,
@@ -189,13 +148,7 @@ function createOrUpdateFundingRoundFactory(
   //Check if these registries already exist/are being tracked
   let recipientRegistryAddress = fundingRoundFactoryContract.recipientRegistry()
   let recipientRegistryId = recipientRegistryAddress.toHexString()
-  let recipientRegistry = RecipientRegistry.load(recipientRegistryId)
-  if (!recipientRegistry) {
-    createRecipientRegistry(
-      fundingRoundFactoryAddress,
-      recipientRegistryAddress
-    )
-  }
+  let recipientRegistry = loadRecipientRegistry(recipientRegistryAddress)
 
   let contributorRegistryAddress = fundingRoundFactoryContract.userRegistry()
   let contributorRegistryId = contributorRegistryAddress.toHexString()

--- a/subgraph/src/OptimisticRecipientRegistryMapping.ts
+++ b/subgraph/src/OptimisticRecipientRegistryMapping.ts
@@ -5,7 +5,8 @@ import {
   RequestSubmitted,
 } from '../generated/OptimisticRecipientRegistry/OptimisticRecipientRegistry'
 
-import { Recipient, RecipientRegistry } from '../generated/schema'
+import { Recipient } from '../generated/schema'
+import { loadRecipientRegistry } from './RecipientRegistry'
 
 // It is also possible to access smart contracts from mappings. For
 // example, the contract that has emitted the event can be connected to
@@ -34,7 +35,7 @@ export function handleRequestResolved(event: RequestResolved): void {
   log.info('handleRequestResolved', [])
 
   let recipientRegistryId = event.address.toHexString()
-  let recipientRegistry = RecipientRegistry.load(recipientRegistryId)
+  let recipientRegistry = loadRecipientRegistry(event.address)
   if (!recipientRegistry) {
     log.warning(
       'handleRequestResolved - ignore unknown recipient registry {} hash {}',
@@ -81,8 +82,8 @@ export function handleRequestSubmitted(event: RequestSubmitted): void {
   log.info('handleRequestSubmitted', [])
   let recipientRegistryId = event.address.toHexString()
 
-  let recipientRegistery = RecipientRegistry.load(recipientRegistryId)
-  if (!recipientRegistery) {
+  let recipientRegistry = loadRecipientRegistry(event.address)
+  if (!recipientRegistry) {
     log.warning(
       'handleRequestSubmitted - ignore unknown recipient registry {} hash {}',
       [event.address.toHexString(), event.transaction.hash.toHex()]

--- a/subgraph/src/RecipientRegistry.ts
+++ b/subgraph/src/RecipientRegistry.ts
@@ -1,0 +1,56 @@
+import { Address, BigInt } from '@graphprotocol/graph-ts'
+import { OptimisticRecipientRegistry as RecipientRegistryContract } from '../generated/OptimisticRecipientRegistry/OptimisticRecipientRegistry'
+
+import { RecipientRegistry, FundingRoundFactory } from '../generated/schema'
+import { OptimisticRecipientRegistry as recipientRegistryTemplate } from '../generated/templates'
+
+/*
+ * Load the recipient registry entity from the subgraph with the given address
+ */
+export function loadRecipientRegistry(
+  address: Address
+): RecipientRegistry | null {
+  let recipientRegistryId = address.toHexString()
+  let recipientRegistry = RecipientRegistry.load(recipientRegistryId)
+  if (!recipientRegistry) {
+    let recipientRegistryContract = RecipientRegistryContract.bind(address)
+    let controller = recipientRegistryContract.try_controller()
+    if (!controller.reverted) {
+      // Recipient registry's controller must be the factory
+      let factoryId = controller.value.toHexString()
+      let factory = FundingRoundFactory.load(factoryId)
+      if (factory) {
+        /* This is our registry, create it */
+        recipientRegistry = new RecipientRegistry(recipientRegistryId)
+        recipientRegistryTemplate.create(address)
+        let baseDeposit = recipientRegistryContract.try_baseDeposit()
+        if (baseDeposit.reverted) {
+          recipientRegistry.baseDeposit = BigInt.fromI32(0)
+          recipientRegistry.challengePeriodDuration = BigInt.fromI32(0)
+        } else {
+          recipientRegistry.baseDeposit = baseDeposit.value
+          let challengePeriodDuration =
+            recipientRegistryContract.challengePeriodDuration()
+          recipientRegistry.challengePeriodDuration = challengePeriodDuration
+        }
+        let controller = recipientRegistryContract.try_controller()
+        let maxRecipients = recipientRegistryContract.try_maxRecipients()
+        let owner = recipientRegistryContract.try_owner()
+
+        if (!controller.reverted) {
+          recipientRegistry.controller = controller.value
+        }
+        if (!maxRecipients.reverted) {
+          recipientRegistry.maxRecipients = maxRecipients.value
+        }
+        if (!owner.reverted) {
+          recipientRegistry.owner = owner.value
+        }
+        recipientRegistry.fundingRoundFactory = factory.id
+        recipientRegistry.save()
+      }
+    }
+  }
+
+  return recipientRegistry
+}

--- a/vue-app/src/api/projects.ts
+++ b/vue-app/src/api/projects.ts
@@ -61,19 +61,6 @@ export async function getRecipientRegistryAddress(roundAddress: string | null): 
   }
 }
 
-export async function getCurrentRecipientRegistryAddress(): Promise<string> {
-  const data = await sdk.GetRecipientRegistryInfo({
-    factoryAddress: factory.address.toLowerCase(),
-  })
-
-  const registryAddress =
-    data.fundingRoundFactory?.currentRound?.recipientRegistry?.id ||
-    data.fundingRoundFactory?.recipientRegistry?.id ||
-    ''
-
-  return registryAddress
-}
-
 export async function getProjects(registryAddress: string, startTime?: number, endTime?: number): Promise<Project[]> {
   if (recipientRegistryType === 'simple') {
     return await SimpleRegistry.getProjects(registryAddress, startTime, endTime)

--- a/vue-app/src/views/RecipientProfile.vue
+++ b/vue-app/src/views/RecipientProfile.vue
@@ -72,10 +72,11 @@
 </template>
 
 <script setup lang="ts">
-import { type Project, getProject, getCurrentRecipientRegistryAddress } from '@/api/projects'
+import { type Project, getProject, getRecipientRegistryAddress } from '@/api/projects'
 import { ensLookup } from '@/utils/accounts'
 import { useAppStore } from '@/stores'
 import { getBlockExplorerByAddress } from '@/utils/explorer'
+import { getCurrentRound } from '@/api/round'
 
 const route = useRoute()
 const appStore = useAppStore()
@@ -86,7 +87,8 @@ const loading = ref<boolean>(true)
 
 onMounted(async () => {
   const recipientId = (route.params.id as string) || ''
-  const recipientRegistryAddress = await getCurrentRecipientRegistryAddress()
+  const currentRoundAddress = appStore.currentRoundAddress || (await getCurrentRound())
+  const recipientRegistryAddress = await getRecipientRegistryAddress(currentRoundAddress)
 
   // retrieve the project information without filtering by the locked or verified status
   const filter = false


### PR DESCRIPTION
This PR ensures that when processing subgraph event, 'AddRecipient', the recipient registry entity exists.  The recipient registry entity could be missing in the case when new recipient registry is set in the funding round factory because the setRegistry event is missing in the contract.  